### PR TITLE
feat: document upload

### DIFF
--- a/frontend/ailixir/package-lock.json
+++ b/frontend/ailixir/package-lock.json
@@ -16,6 +16,7 @@
         "expo": "~55.0.15",
         "expo-constants": "~55.0.14",
         "expo-device": "~55.0.15",
+        "expo-document-picker": "~55.0.13",
         "expo-font": "~55.0.6",
         "expo-glass-effect": "~55.0.10",
         "expo-image": "~55.0.8",
@@ -9351,6 +9352,15 @@
       "dependencies": {
         "ua-parser-js": "^0.7.33"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-55.0.13.tgz",
+      "integrity": "sha512-IhswJElhdzs3fKDEKW8KXYRoFkWGEsXRMYAZT46Yo56zqqy8yQXrczo33RSwD2hFzNQBdLT97SJL9N311UyS3g==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }

--- a/frontend/ailixir/package.json
+++ b/frontend/ailixir/package.json
@@ -19,6 +19,7 @@
     "expo": "~55.0.15",
     "expo-constants": "~55.0.14",
     "expo-device": "~55.0.15",
+    "expo-document-picker": "~55.0.13",
     "expo-font": "~55.0.6",
     "expo-glass-effect": "~55.0.10",
     "expo-image": "~55.0.8",

--- a/frontend/ailixir/src/app/index.tsx
+++ b/frontend/ailixir/src/app/index.tsx
@@ -55,6 +55,10 @@ export default function HomeScreen() {
           <CButton>LogIn</CButton>
         </Link>
 
+        <Link href="/upload" asChild>
+          <CButton>Go to Upload</CButton>
+        </Link>
+
         {Platform.OS === 'web' && <WebBadge />}
       </SafeAreaView>
     </ThemedView>

--- a/frontend/ailixir/src/app/upload.tsx
+++ b/frontend/ailixir/src/app/upload.tsx
@@ -1,0 +1,35 @@
+import * as DocumentPicker from 'expo-document-picker';
+import { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { CButton, CText } from '@/components/atoms';
+import { YStack } from '@tamagui/stacks';
+
+export default function UploadScreen() {
+  const [uploadedFiles, setUploadedFiles] = useState<DocumentPicker.DocumentPickerAsset[]>([]);
+
+  const handlePickFiles = async () => {
+    const pickerResult = await DocumentPicker.getDocumentAsync({
+      type: ['application/pdf', 'image/*'],
+      multiple: true,
+      copyToCacheDirectory: true,
+    });
+
+    if (pickerResult.canceled) {
+      return;
+    }
+
+    setUploadedFiles(pickerResult.assets);
+  };
+
+  return (
+    <SafeAreaView>
+      <YStack gap={5} width={300}>
+        <CButton onPress={handlePickFiles}>Upload File</CButton>
+        {uploadedFiles.map((file, index) => (
+          <CText key={`${file.uri}-${index}`}>{file.name}</CText>
+        ))}
+      </YStack>
+    </SafeAreaView>
+  );
+}


### PR DESCRIPTION
- add an upload route and home screen navigation to access the new flow
- integrate expo-document-picker to select multiple PDF and image files
- display selected file names in the upload screen to confirm user choices