### PR TITLE
fix(backend): restore auth refactor, correct error message, fix Swagger UI auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ serviceAccountKey.json
 *-serviceAccountKey.json
 *.firebase-credentials.json
 gcp-credentials.json
+Backend/secrets/
+secrets/
 
 # Firebase emulator artifacts
 .firebase/

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in real values.
+# .env is gitignored; .env.example is committed so the team knows what to set.
+
+FIREBASE_PROJECT_ID=amos26
+FIREBASE_WEB_API_KEY=..................................... # get from firebase console - Project Settings > General > gooogle-services.json > download
+TEST_USER_EMAIL=test@ailixir.dev
+TEST_USER_PASSWORD=test123

--- a/Backend/api/auth.py
+++ b/Backend/api/auth.py
@@ -1,65 +1,63 @@
-import os
-from pathlib import Path
+"""
+Firebase ID-token authentication for FastAPI endpoints.
+
+Inject `get_current_user` as a dependency on any route that should require a
+signed-in user. The function verifies the bearer token against Firebase Auth and
+returns the decoded user info, or raises 401 if the token is bad.
+
+Credential loading and Firebase app initialisation live in `shared/firestore.py`
+so the API and workers go through one place. Auth code itself stays focused on
+"verify a token, return a user."
+"""
+
+import logging
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from firebase_admin import auth
 
-import firebase_admin
-from firebase_admin import credentials, auth
+from shared.firestore import ensure_firebase_app
 
-# auth.py is inside: Backend/api/auth.py
-# Backend root is:   Backend/
-BACKEND_ROOT = Path(__file__).resolve().parent.parent
-
-FIREBASE_KEY_RELATIVE_PATH = os.getenv(
-    "FIREBASE_KEY_RELATIVE_PATH",
-    "shared/keys/amos26-firebase-adminsdk-fbsvc-c05787eb8f.json",
-)
-
-FIREBASE_KEY_PATH = BACKEND_ROOT / FIREBASE_KEY_RELATIVE_PATH
-
-
-if not firebase_admin._apps:
-    if not FIREBASE_KEY_PATH.exists():
-        raise FileNotFoundError(
-            f"Firebase key file not found.\n"
-            f"Resolved path: {FIREBASE_KEY_PATH}\n"
-            f"auth.py location: {Path(__file__).resolve()}\n"
-            f"Backend root: {BACKEND_ROOT}\n"
-            f"Relative key path: {FIREBASE_KEY_RELATIVE_PATH}"
-        )
-
-    cred = credentials.Certificate(str(FIREBASE_KEY_PATH))
-    firebase_admin.initialize_app(cred)
-
-
+_log = logging.getLogger(__name__)
 _bearer_scheme = HTTPBearer()
 
 
 def get_current_user(
-    credentials_obj: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
+    creds: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
 ) -> dict:
-    token = credentials_obj.credentials
+    """Verify a Firebase ID token and return the decoded user info.
+
+    Returns a dict with `uid` and optionally `email`, `name`, and `email_verified`.
+    Raises HTTP 401 on any token-level failure. Infrastructure errors (e.g. unable
+    to reach Google's certificate endpoint) propagate as 500, which is correct —
+    those are not auth failures and the client retrying the same token won't help.
+    """
+    ensure_firebase_app()
 
     try:
-        decoded = auth.verify_id_token(token)
-
+        decoded = auth.verify_id_token(creds.credentials)
     except auth.ExpiredIdTokenError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token has expired. Please re-authenticate.",
         )
-
-    except auth.InvalidIdTokenError:
+    except auth.RevokedIdTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has been revoked.",
+        )
+    except auth.UserDisabledError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User account is disabled.",
         )
-
-    except Exception:
+    except (auth.InvalidIdTokenError, ValueError) as e:
+        # Generic message to the client; full reason logged server-side so we can
+        # debug invalid tokens without leaking auth internals to attackers.
+        _log.warning("invalid_id_token: %s", e)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentication failed.",
+            detail="Invalid token.",
         )
 
     return {

--- a/Backend/api/main.py
+++ b/Backend/api/main.py
@@ -152,9 +152,11 @@ async def upload_document(
     )
 
 
-# FastAPI auto-generates an OpenAPI schema. We patch it here to inject the HTTP
-# Bearer security scheme so the Swagger UI at /docs shows an "Authorize" button.
-# Without this, devs have to paste tokens into curl manually for every request.
+# FastAPI auto-generates an OpenAPI schema and emits a `HTTPBearer` security scheme
+# whenever a route uses `Depends(HTTPBearer())` — which `get_current_user` does.
+# We just decorate the auto-generated entry with `bearerFormat` and a description so
+# the Swagger UI Authorize dialog shows useful guidance. Replacing the scheme outright
+# would break the per-endpoint `security` references FastAPI already wired up.
 def custom_openapi():
     if app.openapi_schema:
         return app.openapi_schema
@@ -166,15 +168,12 @@ def custom_openapi():
         routes=app.routes,
     )
 
-    schema["components"]["securitySchemes"] = {
-        "BearerAuth": {
-            "type": "http",
-            "scheme": "bearer",
-            "bearerFormat": "JWT",
-            "description": "Paste your Firebase ID token (without the 'Bearer ' prefix)",
-        }
-    }
-    schema["security"] = [{"BearerAuth": []}]
+    schemes = schema.get("components", {}).get("securitySchemes", {})
+    if "HTTPBearer" in schemes:
+        schemes["HTTPBearer"]["bearerFormat"] = "JWT"
+        schemes["HTTPBearer"]["description"] = (
+            "Paste your Firebase ID token (without the 'Bearer ' prefix)"
+        )
 
     app.openapi_schema = schema
     return app.openapi_schema

--- a/Backend/api/requirements.txt
+++ b/Backend/api/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.136.1
 uvicorn==0.46.0
 firebase-admin==7.4.0
 python-multipart==0.0.27
+python-dotenv==1.0.1

--- a/Backend/shared/firestore.py
+++ b/Backend/shared/firestore.py
@@ -12,13 +12,22 @@ That makes local development and CI tests possible without a real service accoun
 
 import os
 import threading
+from pathlib import Path
 
 import firebase_admin
 from firebase_admin import credentials, firestore
 from google.cloud.firestore_v1 import Client
 
-_PROJECT_ID = os.getenv("FIREBASE_PROJECT_ID", "amos26-7b955")
-_CRED_PATH = os.getenv("FIREBASE_CREDENTIALS_PATH", "api/serviceAccountKey.json")
+# Backend root is the parent of this `shared/` directory. Resolving once at import
+# time avoids surprises from changing working directories (e.g. uvicorn vs pytest).
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+_PROJECT_ID = os.getenv("FIREBASE_PROJECT_ID", "amos26")
+_KEY_RELATIVE_PATH = os.getenv(
+    "FIREBASE_KEY_RELATIVE_PATH",
+    "secrets/serviceAccountKey.json",
+)
+_KEY_PATH = BACKEND_ROOT / _KEY_RELATIVE_PATH
 
 _init_lock = threading.Lock()
 _db: Client | None = None
@@ -41,9 +50,17 @@ def ensure_firebase_app() -> None:
             return
         if _emulator_mode():
             firebase_admin.initialize_app(options={"projectId": _PROJECT_ID})
-        else:
-            cred = credentials.Certificate(_CRED_PATH)
-            firebase_admin.initialize_app(cred)
+            return
+        if not _KEY_PATH.exists():
+            raise FileNotFoundError(
+                f"Firebase service account key not found.\n"
+                f"  Expected at: {_KEY_PATH}\n"
+                f"  Backend root: {BACKEND_ROOT}\n"
+                f"  Relative path: {_KEY_RELATIVE_PATH}\n"
+                f"Set FIREBASE_KEY_RELATIVE_PATH to override the default location."
+            )
+        cred = credentials.Certificate(str(_KEY_PATH))
+        firebase_admin.initialize_app(cred)
 
 
 def get_firestore() -> Client:


### PR DESCRIPTION
Restores improvements reverted in commit 516f7fd plus fixes a bug in the custom OpenAPI schema that broke Swagger UI's Authorize flow.

Auth refactor (restored):
- Lazy Firebase init via shared.firestore.ensure_firebase_app() — the app now boots without credentials so tests/CI can run on cold envs.
- Narrow exception handling (Expired / Revoked / UserDisabled / Invalid+Value) instead of a catch-all that masked real errors.
- Server-side logging of invalid tokens via Python's logging module so we can debug bad tokens without leaking auth internals to clients.

Bug fixes:
- auth: InvalidIdTokenError previously returned 'User account is disabled' which was misleading; now correctly returns 'Invalid token'.
- main: custom_openapi() overwrote the entire securitySchemes dict with a new 'BearerAuth' entry, but per-endpoint security still referenced FastAPI's auto-generated 'HTTPBearer'. The mismatch broke Swagger UI: the Authorize dialog reported 'Authorized' but the Authorization header was never attached to outgoing requests. Now we enhance the existing HTTPBearer scheme instead of replacing it.

Infrastructure:
- Centralizes credential-path resolution in shared/firestore.py using a BACKEND_ROOT/Path pattern so paths work regardless of CWD.
- Moves the service account key from Backend/api/ to Backend/secrets/ so all services (api, worker, shared) can reach it equally.
- Adds python-dotenv==1.0.1 to requirements.txt (was imported in main.py but undeclared, broke fresh installs).
- Adds Backend/.env.example so teammates know what env vars to set.
- Updates .gitignore to cover Backend/secrets/ and secrets/ paths.