### PR TITLE
feat(auth): add signup endpoint and user profile

### DIFF
--- a/Backend/api/auth.py
+++ b/Backend/api/auth.py
@@ -1,13 +1,17 @@
 """
-Firebase ID-token authentication for FastAPI endpoints.
+Firebase identity operations for the API service.
 
-Inject `get_current_user` as a dependency on any route that should require a
-signed-in user. The function verifies the bearer token against Firebase Auth and
-returns the decoded user info, or raises 401 if the token is bad.
+Two distinct responsibilities live here:
+
+1. Token verification — `get_current_user` is the FastAPI dependency that turns
+   an `Authorization: Bearer <id_token>` header into a decoded user dict.
+2. User administration — `create_firebase_user` / `delete_firebase_user` wrap
+   the Firebase Admin SDK calls used during signup. Keeping these as thin
+   wrappers gives us one place to log, transform, or replace the underlying
+   call without touching every caller.
 
 Credential loading and Firebase app initialisation live in `shared/firestore.py`
-so the API and workers go through one place. Auth code itself stays focused on
-"verify a token, return a user."
+so the API and workers go through one place.
 """
 
 import logging
@@ -66,3 +70,39 @@ def get_current_user(
         "name": decoded.get("name"),
         "email_verified": decoded.get("email_verified", False),
     }
+
+
+def create_firebase_user(
+    *,
+    email: str,
+    password: str,
+    display_name: str,
+) -> str:
+    """Create a Firebase Auth user and return their UID.
+
+    Re-raises `firebase_admin.auth.EmailAlreadyExistsError` so the caller can map
+    it to an HTTP 409, and `ValueError` for inputs that pass our Pydantic gates
+    but fail the Admin SDK's own rules (e.g. password edge cases). Any other
+    exception bubbles up as a 500.
+    """
+    ensure_firebase_app()
+    record = auth.create_user(
+        email=email,
+        password=password,
+        display_name=display_name,
+    )
+    _log.info("firebase_user_created uid=%s", record.uid)
+    return record.uid
+
+
+def delete_firebase_user(uid: str) -> None:
+    """Delete a Firebase Auth user.
+
+    Used as the compensating action when a signup writes the Auth record but
+    fails to write the Firestore profile. Best-effort: callers should catch and
+    log failures rather than re-raise, since the original error is what we want
+    to surface to the client.
+    """
+    ensure_firebase_app()
+    auth.delete_user(uid)
+    _log.info("firebase_user_deleted uid=%s", uid)

--- a/Backend/api/main.py
+++ b/Backend/api/main.py
@@ -9,17 +9,29 @@ Run from the `Backend/` directory:
     uvicorn api.main:app --reload
 """
 
+import logging
+
+from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, File, HTTPException, UploadFile, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from pydantic import BaseModel
+from firebase_admin import auth as firebase_auth
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
-from api.auth import get_current_user
+from api.auth import (
+    create_firebase_user,
+    delete_firebase_user,
+    get_current_user,
+)
 from shared.models.document import DocumentStatus
+from shared.models.user import UserProfile
 from shared.repositories.documents import create_document
-from dotenv import load_dotenv
+from shared.repositories.users import create_user_profile, get_user_profile
 
 load_dotenv()
+
+_log = logging.getLogger(__name__)
+
 app = FastAPI(
     title="Document Processing API",
     version="1.0.0",
@@ -46,6 +58,42 @@ app.add_middleware(
 )
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Request / response models
+# ──────────────────────────────────────────────────────────────────────────────
+
+class SignupRequest(BaseModel):
+    """Body for POST /auth/signup.
+
+    Password length follows NIST 800-63B: at least 8 characters, no composition
+    rules. The 128-character cap exists to prevent denial-of-service via giant
+    payloads — Firebase Auth itself accepts much longer strings.
+    """
+
+    email: EmailStr
+    password: str = Field(..., min_length=8, max_length=128)
+    first_name: str = Field(..., min_length=1, max_length=50)
+    last_name: str = Field(..., min_length=1, max_length=50)
+
+    @field_validator("first_name", "last_name")
+    @classmethod
+    def _strip_and_reject_empty(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must not be empty or whitespace-only")
+        return stripped
+
+
+class SignupResponse(BaseModel):
+    """Returned on successful signup. The client must call Firebase Auth SDK with
+    the same email + password to obtain an ID token for subsequent API calls."""
+
+    uid: str
+    email: EmailStr
+    first_name: str
+    last_name: str
+
+
 class UploadDocumentResponse(BaseModel):
     document_id: str
     status: DocumentStatus
@@ -57,6 +105,10 @@ _ALLOWED_TYPES = {"application/pdf", "image/jpeg", "image/png", "text/plain"}
 _MAX_SIZE_BYTES = 10 * 1024 * 1024
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# System
+# ──────────────────────────────────────────────────────────────────────────────
+
 @app.get(
     "/health",
     tags=["System"],
@@ -67,23 +119,133 @@ def health() -> dict:
     return {"status": "ok"}
 
 
-@app.get(
-    "/me",
+# ──────────────────────────────────────────────────────────────────────────────
+# Auth
+# ──────────────────────────────────────────────────────────────────────────────
+
+@app.post(
+    "/auth/signup",
+    status_code=status.HTTP_201_CREATED,
+    response_model=SignupResponse,
     tags=["Auth"],
-    summary="Get current user",
-    response_description="Decoded Firebase token claims",
+    summary="Create a new user account",
+    response_description="Account created; client must now sign in via Firebase Auth SDK",
     responses={
-        200: {"description": "User profile from Firebase token"},
-        401: {"description": "Missing or invalid Firebase token"},
+        201: {"description": "Signup successful"},
+        400: {"description": "Inputs rejected by Firebase Admin SDK"},
+        409: {"description": "An account with this email already exists"},
+        422: {"description": "Request body failed validation (email/password/name rules)"},
     },
 )
-def get_me(user: dict = Depends(get_current_user)) -> dict:
-    """Return the authenticated user's profile derived from their Firebase token.
+def signup(payload: SignupRequest) -> SignupResponse:
+    """Create a Firebase Auth user and the matching Firestore profile atomically.
 
-    Useful for verifying auth is working end-to-end.
+    Login itself is NOT a backend endpoint — the mobile client signs in directly
+    with the Firebase Auth SDK to obtain an ID token. This endpoint exists only
+    to atomically capture the profile fields (first_name, last_name) that
+    Firebase Auth does not store.
+
+    Atomicity is best-effort: if the Firestore write fails after the Firebase
+    Auth record is created, we delete the Firebase user to compensate. A real
+    distributed transaction across the two systems is not possible, so a
+    background reconciliation job will eventually be needed for production.
     """
-    return user
+    display_name = f"{payload.first_name} {payload.last_name}"
 
+    try:
+        uid = create_firebase_user(
+            email=payload.email,
+            password=payload.password,
+            display_name=display_name,
+        )
+    except firebase_auth.EmailAlreadyExistsError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An account with this email already exists.",
+        )
+    except ValueError as exc:
+        # Firebase Admin SDK raises ValueError for inputs that pass our Pydantic
+        # gate but fail its own rules. Surface the reason as a 400 so the client
+        # can show it to the user.
+        _log.warning("firebase_create_user_rejected reason=%s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+
+    try:
+        create_user_profile(
+            uid=uid,
+            email=payload.email,
+            first_name=payload.first_name,
+            last_name=payload.last_name,
+        )
+    except Exception as profile_error:
+        # Compensation: roll back the Firebase user so the system never holds an
+        # auth record without a matching profile. If cleanup itself fails we log
+        # the orphan for offline reconciliation and still return 500 to the
+        # client — the original error is what they need to act on.
+        _log.error(
+            "profile_write_failed_compensating uid=%s error=%s",
+            uid, profile_error,
+        )
+        try:
+            delete_firebase_user(uid)
+        except Exception as cleanup_error:
+            # TODO(orphan-cleanup): production needs a periodic job that scans
+            # Firebase Auth for users with no Firestore profile and either
+            # provisions a profile (if recoverable) or deletes the user.
+            _log.error(
+                "orphan_firebase_user uid=%s cleanup_error=%s",
+                uid, cleanup_error,
+            )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Signup failed; please retry.",
+        )
+
+    _log.info("signup_succeeded uid=%s", uid)
+
+    return SignupResponse(
+        uid=uid,
+        email=payload.email,
+        first_name=payload.first_name,
+        last_name=payload.last_name,
+    )
+
+
+@app.get(
+    "/me",
+    response_model=UserProfile,
+    tags=["Auth"],
+    summary="Get current user profile",
+    response_description="Profile from Firestore, keyed by the authenticated Firebase UID",
+    responses={
+        200: {"description": "Profile returned"},
+        401: {"description": "Missing or invalid Firebase token"},
+        404: {"description": "Profile not found — user must complete signup via /auth/signup"},
+    },
+)
+def get_me(user: dict = Depends(get_current_user)) -> UserProfile:
+    """Return the authenticated user's profile.
+
+    A 404 here typically means the user was created directly in the Firebase
+    Console without going through /auth/signup — there's an Auth record but no
+    profile. The fix is to delete the Auth record and have the user sign up
+    properly through the API.
+    """
+    profile = get_user_profile(user["uid"])
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User profile not found. Please complete signup.",
+        )
+    return profile
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Documents
+# ──────────────────────────────────────────────────────────────────────────────
 
 @app.post(
     "/documents/upload",
@@ -151,6 +313,10 @@ async def upload_document(
         size_bytes=document.size_bytes,
     )
 
+
+# ──────────────────────────────────────────────────────────────────────────────
+# OpenAPI customisation
+# ──────────────────────────────────────────────────────────────────────────────
 
 # FastAPI auto-generates an OpenAPI schema and emits a `HTTPBearer` security scheme
 # whenever a route uses `Depends(HTTPBearer())` — which `get_current_user` does.

--- a/Backend/api/requirements.txt
+++ b/Backend/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.46.0
 firebase-admin==7.4.0
 python-multipart==0.0.27
 python-dotenv==1.0.1
+email-validator==2.2.0

--- a/Backend/shared/models/user.py
+++ b/Backend/shared/models/user.py
@@ -1,0 +1,21 @@
+"""
+Domain model for a user's application profile.
+
+A `UserProfile` is the row in the `users` Firestore collection that holds the
+fields Firebase Auth does not store (first_name, last_name, server timestamps).
+The Firebase UID is both the document id in Firestore and the join key with the
+Firebase Auth user record.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserProfile(BaseModel):
+    uid: str
+    email: EmailStr
+    first_name: str
+    last_name: str
+    created_at: datetime
+    updated_at: datetime

--- a/Backend/shared/repositories/users.py
+++ b/Backend/shared/repositories/users.py
@@ -1,0 +1,67 @@
+"""
+Repository for the `users` Firestore collection.
+
+Each document is keyed by Firebase UID so the profile and the Firebase Auth
+record share an identifier. Callers go through these functions instead of
+touching Firestore directly; this is the seam where caching or a fake
+implementation for tests would slot in.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from firebase_admin import firestore
+
+from shared.firestore import get_firestore
+from shared.models.user import UserProfile
+
+_log = logging.getLogger(__name__)
+_COLLECTION = "users"
+
+
+def create_user_profile(
+    *,
+    uid: str,
+    email: str,
+    first_name: str,
+    last_name: str,
+) -> UserProfile:
+    """Persist a new user profile, keyed by Firebase UID.
+
+    The returned object uses client-side timestamps as a best-effort approximation;
+    the canonical values written to Firestore are SERVER_TIMESTAMP and may differ
+    by up to a few hundred milliseconds.
+    """
+    db = get_firestore()
+    now = datetime.now(timezone.utc)
+
+    db.collection(_COLLECTION).document(uid).set(
+        {
+            "uid": uid,
+            "email": email,
+            "first_name": first_name,
+            "last_name": last_name,
+            "created_at": firestore.SERVER_TIMESTAMP,
+            "updated_at": firestore.SERVER_TIMESTAMP,
+        }
+    )
+
+    _log.info("user_profile_created uid=%s", uid)
+
+    return UserProfile(
+        uid=uid,
+        email=email,
+        first_name=first_name,
+        last_name=last_name,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def get_user_profile(uid: str) -> UserProfile | None:
+    """Fetch a user profile by Firebase UID. Returns None if not found."""
+    db = get_firestore()
+    snapshot = db.collection(_COLLECTION).document(uid).get()
+    if not snapshot.exists:
+        return None
+    return UserProfile(**snapshot.to_dict())


### PR DESCRIPTION
POST /auth/signup atomically creates a Firebase Auth user and a Firestore profile record. Compensates by deleting the Firebase user if the profile write fails so we don't leak orphans. Validates email format, password length (NIST: 8 chars min), and trimmed first/last names via Pydantic.

GET /me now returns a typed UserProfile merged from Firestore — 404 if the profile is missing (user must complete signup via /auth/signup).

Adds User model, users repository, and email-validator dependency."