### PR TITLE
feat(documents): multi-file upload via signed URLs, list/get/delete

### DIFF
--- a/Backend/.dockerignore
+++ b/Backend/.dockerignore
@@ -1,0 +1,35 @@
+# Never bake credentials into the container.
+secrets/
+.env
+.env.*
+!.env.example
+
+# Local virtualenv.
+.venv/
+venv/
+
+# Python build / cache artefacts.
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Editor / OS noise.
+.DS_Store
+.vscode/
+.idea/
+
+# Terraform state (per-service, never inside the image).
+terraform/.terraform/
+terraform/*.tfstate*
+terraform/terraform.tfvars
+
+# Repo-level docs and tests aren't needed at runtime.
+Documentation/
+tests/
+*.md
+!README.md

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,7 +1,39 @@
 # Copy this file to .env and fill in real values.
 # .env is gitignored; .env.example is committed so the team knows what to set.
 
+# ── Firebase ─────────────────────────────────────────────────────────────────
 FIREBASE_PROJECT_ID=amos26
-FIREBASE_WEB_API_KEY=..................................... # get from firebase console - Project Settings > General > gooogle-services.json > download
+# get from firebase console - Project Settings > General > Web API Key
+# (also embedded in google-services.json / GoogleService-Info.plist)
+FIREBASE_WEB_API_KEY=...
+
+# Path to the Firebase Admin SDK service account JSON, RELATIVE to Backend/.
+# Default points at the gitignored secrets/ folder.
+FIREBASE_KEY_RELATIVE_PATH=secrets/serviceAccountKey.json
+
+# ── GCS ──────────────────────────────────────────────────────────────────────
+# Bucket terraform provisions for document files. Must exist before the API
+# generates signed URLs against it.
+GCS_BUCKET_NAME=ailixir-documents-amos26
+
+# Signed-URL TTL (seconds). Default 900 = 15 minutes.
+GCS_SIGNED_URL_TTL_SECONDS=900
+
+# ── Pub/Sub ──────────────────────────────────────────────────────────────────
+# Topic the API publishes DocumentUploaded events to. Must match terraform.
+PUBSUB_TOPIC_DOCUMENT_UPLOADED=document-uploaded
+
+# ── Workers ──────────────────────────────────────────────────────────────────
+# OIDC values the worker checks on every Pub/Sub push.
+# Audience: the worker's Cloud Run URL. Trusted email: the SA terraform creates
+# for the Pub/Sub subscription's push_config.oidc_token.
+PUBSUB_PUSH_AUDIENCE=
+PUBSUB_PUSH_SERVICE_ACCOUNT=
+
+# Local dev only — skip OIDC verification so the Pub/Sub emulator works.
+# Never set to 1 in production.
+PUBSUB_SKIP_OIDC_VERIFICATION=0
+
+# ── Test fixtures (used by scripts/get-token.sh, not the runtime) ────────────
 TEST_USER_EMAIL=test@ailixir.dev
-TEST_USER_PASSWORD=test123
+TEST_USER_PASSWORD=test1234

--- a/Backend/api/errors.py
+++ b/Backend/api/errors.py
@@ -2,8 +2,8 @@
 Exception types and handlers that emit structured error responses.
 
 Every error response carries a stable `code` so mobile clients can switch on
-it without parsing message strings, plus the `request_id` so support
-can trace a complaint to exact log lines.
+it without parsing message strings, plus the `request_id` so support can
+trace a complaint to exact log lines.
 """
 
 import logging
@@ -28,6 +28,9 @@ class APIError(HTTPException):
 
 
 def _envelope(code: ErrorCode, message: str) -> dict:
+    """Build the structured error body. Reads the request id from the
+    contextvar — the pure-ASGI middleware in `api/middleware.py` guarantees
+    propagation through the exception-handler scope."""
     return ErrorResponse(
         error=ErrorDetail(
             code=code,
@@ -45,13 +48,9 @@ async def http_exception_handler(_: Request, exc: StarletteHTTPException) -> JSO
     """Wrap FastAPI/Starlette's built-in HTTPExceptions into our envelope.
 
     Covers things like the 403 emitted by `HTTPBearer` when the Authorization
-    header is missing entirely. Our own domain errors go through `APIError` and
-    its dedicated handler, so the mapping here is intentionally narrow — we
-    only map statuses that the framework itself produces.
+    header is missing entirely. Domain errors flow through `APIError` and its
+    dedicated handler, so the mapping here is intentionally narrow.
     """
-    # 401/403: missing or rejected bearer credentials (FastAPI's HTTPBearer).
-    # Everything else gets a generic code so we don't mis-label, e.g., a
-    # path-not-found as a "DOCUMENT_NOT_FOUND".
     code = {
         401: ErrorCode.UNAUTHENTICATED,
         403: ErrorCode.UNAUTHENTICATED,
@@ -63,7 +62,7 @@ async def http_exception_handler(_: Request, exc: StarletteHTTPException) -> JSO
 async def validation_error_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
     """Flatten Pydantic's structured errors into a single human-readable message.
 
-    We surface up to three field errors — enough for the client to fix one
+    Surfaces up to three field errors — enough for the client to fix one
     request without dumping a wall of text on the user.
     """
     parts = []
@@ -75,7 +74,8 @@ async def validation_error_handler(_: Request, exc: RequestValidationError) -> J
 
 
 async def unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
-    """Last-resort handler. Logs the full stack server-side; client gets the code only."""
+    """Last-resort handler. Logs the full stack server-side; client gets only
+    the generic code plus the request id for tracing."""
     _log.exception("unhandled_exception: %s", exc)
     return JSONResponse(
         status_code=500,

--- a/Backend/api/errors.py
+++ b/Backend/api/errors.py
@@ -27,24 +27,37 @@ class APIError(HTTPException):
         self.code = code
 
 
-def _envelope(code: ErrorCode, message: str) -> dict:
-    """Build the structured error body. Reads the request id from the
-    contextvar — the pure-ASGI middleware in `api/middleware.py` guarantees
-    propagation through the exception-handler scope."""
+def _resolve_request_id(request: Request) -> str | None:
+    """Pick the request id from the most reliable source.
+
+    `request.state.request_id` is backed by the ASGI scope and survives every
+    middleware boundary, including FastAPI's ServerErrorMiddleware (which runs
+    the bare `Exception`/500 handler from a scope outside our RequestIDMiddleware).
+    The contextvar is the secondary source for callers that don't have a
+    request handle (log records, background helpers).
+    """
+    rid = getattr(request.state, "request_id", "") or request_id_var.get("")
+    return rid or None
+
+
+def _envelope(request: Request, code: ErrorCode, message: str) -> dict:
     return ErrorResponse(
         error=ErrorDetail(
             code=code,
             message=message,
-            request_id=request_id_var.get("") or None,
+            request_id=_resolve_request_id(request),
         )
     ).model_dump()
 
 
-async def api_error_handler(_: Request, exc: APIError) -> JSONResponse:
-    return JSONResponse(status_code=exc.status_code, content=_envelope(exc.code, exc.detail))
+async def api_error_handler(request: Request, exc: APIError) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=_envelope(request, exc.code, exc.detail),
+    )
 
 
-async def http_exception_handler(_: Request, exc: StarletteHTTPException) -> JSONResponse:
+async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
     """Wrap FastAPI/Starlette's built-in HTTPExceptions into our envelope.
 
     Covers things like the 403 emitted by `HTTPBearer` when the Authorization
@@ -56,10 +69,13 @@ async def http_exception_handler(_: Request, exc: StarletteHTTPException) -> JSO
         403: ErrorCode.UNAUTHENTICATED,
     }.get(exc.status_code, ErrorCode.INTERNAL_SERVER_ERROR)
     message = exc.detail if isinstance(exc.detail, str) else "request failed"
-    return JSONResponse(status_code=exc.status_code, content=_envelope(code, message))
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=_envelope(request, code, message),
+    )
 
 
-async def validation_error_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
+async def validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     """Flatten Pydantic's structured errors into a single human-readable message.
 
     Surfaces up to three field errors — enough for the client to fix one
@@ -70,14 +86,19 @@ async def validation_error_handler(_: Request, exc: RequestValidationError) -> J
         loc = ".".join(str(x) for x in err.get("loc", ()) if x != "body")
         parts.append(f"{loc}: {err['msg']}" if loc else err["msg"])
     message = "; ".join(parts) or "validation failed"
-    return JSONResponse(status_code=422, content=_envelope(ErrorCode.VALIDATION_FAILED, message))
+    return JSONResponse(
+        status_code=422,
+        content=_envelope(request, ErrorCode.VALIDATION_FAILED, message),
+    )
 
 
-async def unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
-    """Last-resort handler. Logs the full stack server-side; client gets only
-    the generic code plus the request id for tracing."""
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Last-resort handler. Runs from ServerErrorMiddleware (outermost), so
+    `request.state` is the only reliable carrier for the request id here —
+    the contextvar from our inner middleware is already reset by this point.
+    """
     _log.exception("unhandled_exception: %s", exc)
     return JSONResponse(
         status_code=500,
-        content=_envelope(ErrorCode.INTERNAL_SERVER_ERROR, "An internal error occurred."),
+        content=_envelope(request, ErrorCode.INTERNAL_SERVER_ERROR, "An internal error occurred."),
     )

--- a/Backend/api/errors.py
+++ b/Backend/api/errors.py
@@ -1,0 +1,83 @@
+"""
+Exception types and handlers that emit structured error responses.
+
+Every error response carries a stable `code` so mobile clients can switch on
+it without parsing message strings, plus the `request_id` so support
+can trace a complaint to exact log lines.
+"""
+
+import logging
+
+from fastapi import HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from api.middleware import request_id_var
+from shared.models.errors import ErrorCode, ErrorDetail, ErrorResponse
+
+_log = logging.getLogger(__name__)
+
+
+class APIError(HTTPException):
+    """Domain-specific HTTP error carrying a stable `ErrorCode`."""
+
+    def __init__(self, status_code: int, code: ErrorCode, message: str):
+        super().__init__(status_code=status_code, detail=message)
+        self.code = code
+
+
+def _envelope(code: ErrorCode, message: str) -> dict:
+    return ErrorResponse(
+        error=ErrorDetail(
+            code=code,
+            message=message,
+            request_id=request_id_var.get("") or None,
+        )
+    ).model_dump()
+
+
+async def api_error_handler(_: Request, exc: APIError) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content=_envelope(exc.code, exc.detail))
+
+
+async def http_exception_handler(_: Request, exc: StarletteHTTPException) -> JSONResponse:
+    """Wrap FastAPI/Starlette's built-in HTTPExceptions into our envelope.
+
+    Covers things like the 403 emitted by `HTTPBearer` when the Authorization
+    header is missing entirely. Our own domain errors go through `APIError` and
+    its dedicated handler, so the mapping here is intentionally narrow — we
+    only map statuses that the framework itself produces.
+    """
+    # 401/403: missing or rejected bearer credentials (FastAPI's HTTPBearer).
+    # Everything else gets a generic code so we don't mis-label, e.g., a
+    # path-not-found as a "DOCUMENT_NOT_FOUND".
+    code = {
+        401: ErrorCode.UNAUTHENTICATED,
+        403: ErrorCode.UNAUTHENTICATED,
+    }.get(exc.status_code, ErrorCode.INTERNAL_SERVER_ERROR)
+    message = exc.detail if isinstance(exc.detail, str) else "request failed"
+    return JSONResponse(status_code=exc.status_code, content=_envelope(code, message))
+
+
+async def validation_error_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
+    """Flatten Pydantic's structured errors into a single human-readable message.
+
+    We surface up to three field errors — enough for the client to fix one
+    request without dumping a wall of text on the user.
+    """
+    parts = []
+    for err in exc.errors()[:3]:
+        loc = ".".join(str(x) for x in err.get("loc", ()) if x != "body")
+        parts.append(f"{loc}: {err['msg']}" if loc else err["msg"])
+    message = "; ".join(parts) or "validation failed"
+    return JSONResponse(status_code=422, content=_envelope(ErrorCode.VALIDATION_FAILED, message))
+
+
+async def unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+    """Last-resort handler. Logs the full stack server-side; client gets the code only."""
+    _log.exception("unhandled_exception: %s", exc)
+    return JSONResponse(
+        status_code=500,
+        content=_envelope(ErrorCode.INTERNAL_SERVER_ERROR, "An internal error occurred."),
+    )

--- a/Backend/api/main.py
+++ b/Backend/api/main.py
@@ -1,36 +1,86 @@
 """
 Ailixir Documents API.
 
-Sync HTTP entrypoint for the mobile client. The endpoints here are tuned for low
-latency: heavy work (OCR, LLM extraction, embedding) lives in the worker services
-and is reached asynchronously via Pub/Sub.
+Sync HTTP entrypoint for the mobile client. The API never streams file bytes
+through itself — clients receive time-limited signed URLs and upload directly
+to GCS. Heavy AI work (OCR, extraction) happens in the worker service,
+triggered via Pub/Sub events the API publishes after finalize.
 
 Run from the `Backend/` directory:
     uvicorn api.main:app --reload
 """
 
+import asyncio
 import logging
+import os
+import re
+import unicodedata
+from datetime import datetime, timezone
+from typing import Annotated
 
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, File, HTTPException, UploadFile, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from firebase_admin import auth as firebase_auth
 from pydantic import BaseModel, EmailStr, Field, field_validator
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from api.auth import (
     create_firebase_user,
     delete_firebase_user,
     get_current_user,
 )
-from shared.models.document import DocumentStatus
+from api.errors import (
+    APIError,
+    api_error_handler,
+    http_exception_handler,
+    unhandled_exception_handler,
+    validation_error_handler,
+)
+from api.middleware import RequestIDLogFilter, RequestIDMiddleware
+from shared import gcs, pubsub
+from shared.models.document import (
+    ALLOWED_FILE_CONTENT_TYPES,
+    EXTENSION_BY_CONTENT_TYPE,
+    MAX_FILE_SIZE_BYTES,
+    MAX_FILES_PER_DOCUMENT,
+    MAX_TOTAL_SIZE_BYTES,
+    SUPPORTED_DOMAINS,
+    Document,
+    DocumentFile,
+    DocumentStatus,
+)
+from shared.models.errors import ErrorCode
 from shared.models.user import UserProfile
-from shared.repositories.documents import create_document
+from shared.repositories.documents import (
+    DocumentStateError,
+    FileCreationSpec,
+    create_document_with_files,
+    decode_cursor,
+    find_document_by_idempotency_key,
+    find_document_for_user,
+    list_documents_for_user,
+    mark_uploaded,
+    pending_files,
+    soft_delete,
+)
 from shared.repositories.users import create_user_profile, get_user_profile
 
 load_dotenv()
 
+# Inject request id into every log line. Format is keep-it-simple key=value so
+# Cloud Logging parses it reasonably without a custom JSON formatter for v1.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s request_id=%(request_id)s %(message)s",
+)
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RequestIDLogFilter())
+
 _log = logging.getLogger(__name__)
+
 
 app = FastAPI(
     title="Document Processing API",
@@ -47,6 +97,8 @@ app = FastAPI(
     openapi_url="/openapi.json",
 )
 
+app.add_middleware(RequestIDMiddleware)
+
 # CORS only matters to browser clients. React Native does not enforce it. The
 # middleware is kept so the FastAPI Swagger UI at /docs works during local dev.
 app.add_middleware(
@@ -57,18 +109,39 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.add_exception_handler(APIError, api_error_handler)
+app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+app.add_exception_handler(RequestValidationError, validation_error_handler)
+app.add_exception_handler(Exception, unhandled_exception_handler)
+
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Request / response models
+# Shared validation helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Characters we never let into a stored file name. Excludes path separators
+# (defence in depth — we don't trust the client name even though the GCS path
+# is built server-side from `file_id`), and ASCII control characters.
+_INVALID_FILENAME_CHARS = re.compile(r"[\\/:\*\?\"<>\|\x00-\x1f]")
+
+
+def _sanitize_filename(name: str) -> str:
+    """Strip path components, control chars, and unicode lookalikes; cap length."""
+    name = os.path.basename(name)
+    name = unicodedata.normalize("NFKC", name)
+    name = _INVALID_FILENAME_CHARS.sub("", name).strip()
+    if not name or name.startswith(".") or name in {".", ".."}:
+        raise ValueError("file_name resolves to empty or reserved value")
+    return name[:255]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Auth — request / response models
 # ──────────────────────────────────────────────────────────────────────────────
 
 class SignupRequest(BaseModel):
-    """Body for POST /auth/signup.
-
-    Password length follows NIST 800-63B: at least 8 characters, no composition
-    rules. The 128-character cap exists to prevent denial-of-service via giant
-    payloads — Firebase Auth itself accepts much longer strings.
-    """
+    """Body for POST /auth/signup. NIST 800-63B password policy: 8 chars min,
+    no composition rules. The 128-char cap prevents giant-payload DoS."""
 
     email: EmailStr
     password: str = Field(..., min_length=8, max_length=128)
@@ -85,8 +158,7 @@ class SignupRequest(BaseModel):
 
 
 class SignupResponse(BaseModel):
-    """Returned on successful signup. The client must call Firebase Auth SDK with
-    the same email + password to obtain an ID token for subsequent API calls."""
+    """Client must now sign in via Firebase Auth SDK to obtain an ID token."""
 
     uid: str
     email: EmailStr
@@ -94,15 +166,142 @@ class SignupResponse(BaseModel):
     last_name: str
 
 
-class UploadDocumentResponse(BaseModel):
+# ──────────────────────────────────────────────────────────────────────────────
+# Documents — request / response models
+# ──────────────────────────────────────────────────────────────────────────────
+
+class CreateDocumentFileRequest(BaseModel):
+    file_name: str = Field(..., min_length=1, max_length=512)
+    content_type: str
+    size_bytes: int = Field(..., gt=0)
+
+    @field_validator("file_name")
+    @classmethod
+    def _sanitize(cls, value: str) -> str:
+        try:
+            return _sanitize_filename(value)
+        except ValueError as exc:
+            raise ValueError(str(exc))
+
+    @field_validator("content_type")
+    @classmethod
+    def _check_content_type(cls, value: str) -> str:
+        if value not in ALLOWED_FILE_CONTENT_TYPES:
+            raise ValueError(
+                f"unsupported content_type {value!r}; "
+                f"allowed: {sorted(ALLOWED_FILE_CONTENT_TYPES)}"
+            )
+        return value
+
+    @field_validator("size_bytes")
+    @classmethod
+    def _check_size(cls, value: int) -> int:
+        if value > MAX_FILE_SIZE_BYTES:
+            raise ValueError(
+                f"size_bytes exceeds per-file limit of {MAX_FILE_SIZE_BYTES} bytes"
+            )
+        return value
+
+
+class CreateDocumentRequest(BaseModel):
+    domain: str
+    title: str | None = Field(default=None, max_length=200)
+    files: list[CreateDocumentFileRequest] = Field(..., min_length=1, max_length=MAX_FILES_PER_DOCUMENT)
+
+    @field_validator("domain")
+    @classmethod
+    def _check_domain(cls, value: str) -> str:
+        if value not in SUPPORTED_DOMAINS:
+            raise ValueError(
+                f"unsupported domain {value!r}; allowed: {sorted(SUPPORTED_DOMAINS)}"
+            )
+        return value
+
+    @field_validator("title")
+    @classmethod
+    def _strip_title(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+
+class DocumentFileUploadInstruction(BaseModel):
+    """Everything the client needs to PUT one file to GCS.
+
+    The signed URL binds method, content type, and size range — the client must
+    send these headers exactly or GCS rejects the upload.
+    """
+
+    file_id: str
+    file_name: str
+    content_type: str
+    size_bytes: int
+    upload_method: str = "PUT"
+    upload_url: str
+    upload_headers: dict[str, str]
+    upload_expires_at: datetime
+
+
+class CreateDocumentResponse(BaseModel):
     document_id: str
     status: DocumentStatus
+    domain: str
+    title: str | None
+    file_count: int
+    total_bytes: int
+    files: list[DocumentFileUploadInstruction]
+    created_at: datetime
+
+
+class DocumentFileResponse(BaseModel):
+    file_id: str
     file_name: str
+    content_type: str
     size_bytes: int
+    upload_completed_at: datetime | None
+    download_url: str | None
+    download_expires_at: datetime | None
 
 
-_ALLOWED_TYPES = {"application/pdf", "image/jpeg", "image/png", "text/plain"}
-_MAX_SIZE_BYTES = 10 * 1024 * 1024
+class DocumentResponse(BaseModel):
+    document_id: str
+    status: DocumentStatus
+    domain: str
+    title: str | None
+    file_count: int
+    total_bytes: int
+    files: list[DocumentFileResponse]
+    created_at: datetime
+    updated_at: datetime
+    finalized_at: datetime | None
+
+
+class DocumentListItem(BaseModel):
+    """List-view summary. No download URLs to keep response size bounded."""
+
+    document_id: str
+    status: DocumentStatus
+    domain: str
+    title: str | None
+    file_count: int
+    total_bytes: int
+    created_at: datetime
+    updated_at: datetime
+    finalized_at: datetime | None
+    thumbnail_url: str | None
+    thumbnail_expires_at: datetime | None
+
+
+class ListDocumentsResponse(BaseModel):
+    documents: list[DocumentListItem]
+    next_cursor: str | None
+
+
+class RefreshUploadURLsResponse(BaseModel):
+    document_id: str
+    status: DocumentStatus
+    files: list[DocumentFileUploadInstruction]
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -130,12 +329,6 @@ def health() -> dict:
     tags=["Auth"],
     summary="Create a new user account",
     response_description="Account created; client must now sign in via Firebase Auth SDK",
-    responses={
-        201: {"description": "Signup successful"},
-        400: {"description": "Inputs rejected by Firebase Admin SDK"},
-        409: {"description": "An account with this email already exists"},
-        422: {"description": "Request body failed validation (email/password/name rules)"},
-    },
 )
 def signup(payload: SignupRequest) -> SignupResponse:
     """Create a Firebase Auth user and the matching Firestore profile atomically.
@@ -144,11 +337,6 @@ def signup(payload: SignupRequest) -> SignupResponse:
     with the Firebase Auth SDK to obtain an ID token. This endpoint exists only
     to atomically capture the profile fields (first_name, last_name) that
     Firebase Auth does not store.
-
-    Atomicity is best-effort: if the Firestore write fails after the Firebase
-    Auth record is created, we delete the Firebase user to compensate. A real
-    distributed transaction across the two systems is not possible, so a
-    background reconciliation job will eventually be needed for production.
     """
     display_name = f"{payload.first_name} {payload.last_name}"
 
@@ -159,18 +347,17 @@ def signup(payload: SignupRequest) -> SignupResponse:
             display_name=display_name,
         )
     except firebase_auth.EmailAlreadyExistsError:
-        raise HTTPException(
+        raise APIError(
             status_code=status.HTTP_409_CONFLICT,
-            detail="An account with this email already exists.",
+            code=ErrorCode.EMAIL_ALREADY_EXISTS,
+            message="An account with this email already exists.",
         )
     except ValueError as exc:
-        # Firebase Admin SDK raises ValueError for inputs that pass our Pydantic
-        # gate but fail its own rules. Surface the reason as a 400 so the client
-        # can show it to the user.
         _log.warning("firebase_create_user_rejected reason=%s", exc)
-        raise HTTPException(
+        raise APIError(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            code=ErrorCode.VALIDATION_FAILED,
+            message=str(exc),
         )
 
     try:
@@ -181,31 +368,19 @@ def signup(payload: SignupRequest) -> SignupResponse:
             last_name=payload.last_name,
         )
     except Exception as profile_error:
-        # Compensation: roll back the Firebase user so the system never holds an
-        # auth record without a matching profile. If cleanup itself fails we log
-        # the orphan for offline reconciliation and still return 500 to the
-        # client — the original error is what they need to act on.
-        _log.error(
-            "profile_write_failed_compensating uid=%s error=%s",
-            uid, profile_error,
-        )
+        _log.error("profile_write_failed_compensating uid=%s error=%s", uid, profile_error)
         try:
             delete_firebase_user(uid)
         except Exception as cleanup_error:
-            # TODO(orphan-cleanup): production needs a periodic job that scans
-            # Firebase Auth for users with no Firestore profile and either
-            # provisions a profile (if recoverable) or deletes the user.
-            _log.error(
-                "orphan_firebase_user uid=%s cleanup_error=%s",
-                uid, cleanup_error,
-            )
-        raise HTTPException(
+            # Orphan Firebase user; reconciliation job picks this up later.
+            _log.error("orphan_firebase_user uid=%s cleanup_error=%s", uid, cleanup_error)
+        raise APIError(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Signup failed; please retry.",
+            code=ErrorCode.INTERNAL_SERVER_ERROR,
+            message="Signup failed; please retry.",
         )
 
     _log.info("signup_succeeded uid=%s", uid)
-
     return SignupResponse(
         uid=uid,
         email=payload.email,
@@ -219,111 +394,436 @@ def signup(payload: SignupRequest) -> SignupResponse:
     response_model=UserProfile,
     tags=["Auth"],
     summary="Get current user profile",
-    response_description="Profile from Firestore, keyed by the authenticated Firebase UID",
-    responses={
-        200: {"description": "Profile returned"},
-        401: {"description": "Missing or invalid Firebase token"},
-        404: {"description": "Profile not found — user must complete signup via /auth/signup"},
-    },
 )
 def get_me(user: dict = Depends(get_current_user)) -> UserProfile:
-    """Return the authenticated user's profile.
+    """Return the authenticated user's Firestore profile.
 
-    A 404 here typically means the user was created directly in the Firebase
-    Console without going through /auth/signup — there's an Auth record but no
-    profile. The fix is to delete the Auth record and have the user sign up
-    properly through the API.
+    404 if the profile is missing — typically a user that was created directly
+    in Firebase Console without going through /auth/signup.
     """
     profile = get_user_profile(user["uid"])
     if profile is None:
-        raise HTTPException(
+        raise APIError(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="User profile not found. Please complete signup.",
+            code=ErrorCode.USER_PROFILE_NOT_FOUND,
+            message="User profile not found. Please complete signup.",
         )
     return profile
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Documents
+# Documents — helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _upload_headers_for(file: DocumentFile) -> dict[str, str]:
+    """Headers the client must send when PUTting to GCS, in addition to the
+    body. The signed URL signature includes these — mismatches cause 403."""
+    return {
+        "Content-Type": file.content_type,
+        "x-goog-content-length-range": f"0,{file.size_bytes}",
+        "x-goog-if-generation-match": "0",
+    }
+
+
+def _make_upload_instruction(file: DocumentFile) -> DocumentFileUploadInstruction:
+    upload_url = gcs.generate_upload_url(
+        object_path=file.gcs_object_path,
+        content_type=file.content_type,
+        max_size_bytes=file.size_bytes,
+    )
+    return DocumentFileUploadInstruction(
+        file_id=file.file_id,
+        file_name=file.file_name,
+        content_type=file.content_type,
+        size_bytes=file.size_bytes,
+        upload_url=upload_url,
+        upload_headers=_upload_headers_for(file),
+        upload_expires_at=datetime.now(timezone.utc) + gcs.DEFAULT_SIGNED_URL_TTL,
+    )
+
+
+def _make_file_response(file: DocumentFile) -> DocumentFileResponse:
+    """Build the read-side representation of a file. Download URL only for
+    files whose upload completed."""
+    download_url: str | None = None
+    download_expires_at: datetime | None = None
+    if file.upload_completed_at is not None:
+        download_url = gcs.generate_download_url(object_path=file.gcs_object_path)
+        download_expires_at = datetime.now(timezone.utc) + gcs.DEFAULT_SIGNED_URL_TTL
+    return DocumentFileResponse(
+        file_id=file.file_id,
+        file_name=file.file_name,
+        content_type=file.content_type,
+        size_bytes=file.size_bytes,
+        upload_completed_at=file.upload_completed_at,
+        download_url=download_url,
+        download_expires_at=download_expires_at,
+    )
+
+
+def _to_document_response(document: Document) -> DocumentResponse:
+    return DocumentResponse(
+        document_id=document.id,
+        status=document.status,
+        domain=document.domain,
+        title=document.title,
+        file_count=document.file_count,
+        total_bytes=document.total_bytes,
+        files=[_make_file_response(f) for f in document.files],
+        created_at=document.created_at,
+        updated_at=document.updated_at,
+        finalized_at=document.finalized_at,
+    )
+
+
+def _to_list_item(document: Document) -> DocumentListItem:
+    """Summary representation. Includes one signed download URL (the first
+    completed file) as a thumbnail; full URLs require GET /documents/{id}."""
+    first_completed = next((f for f in document.files if f.upload_completed_at), None)
+    thumb_url: str | None = None
+    thumb_expires: datetime | None = None
+    if first_completed is not None:
+        thumb_url = gcs.generate_download_url(object_path=first_completed.gcs_object_path)
+        thumb_expires = datetime.now(timezone.utc) + gcs.DEFAULT_SIGNED_URL_TTL
+    return DocumentListItem(
+        document_id=document.id,
+        status=document.status,
+        domain=document.domain,
+        title=document.title,
+        file_count=document.file_count,
+        total_bytes=document.total_bytes,
+        created_at=document.created_at,
+        updated_at=document.updated_at,
+        finalized_at=document.finalized_at,
+        thumbnail_url=thumb_url,
+        thumbnail_expires_at=thumb_expires,
+    )
+
+
+def _enforce_total_size(files: list[CreateDocumentFileRequest]) -> None:
+    total = sum(f.size_bytes for f in files)
+    if total > MAX_TOTAL_SIZE_BYTES:
+        raise APIError(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            code=ErrorCode.TOTAL_SIZE_EXCEEDED,
+            message=(
+                f"declared total of {total} bytes exceeds limit of "
+                f"{MAX_TOTAL_SIZE_BYTES} bytes"
+            ),
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Documents — endpoints
 # ──────────────────────────────────────────────────────────────────────────────
 
 @app.post(
-    "/documents/upload",
+    "/documents",
     status_code=status.HTTP_201_CREATED,
-    response_model=UploadDocumentResponse,
+    response_model=CreateDocumentResponse,
     tags=["Documents"],
-    summary="Upload a document",
-    response_description="Document tracking record created",
-    responses={
-        201: {"description": "Document accepted; tracking record created in Firestore"},
-        401: {"description": "Missing or invalid Firebase token"},
-        413: {"description": "File exceeds 10 MB size limit"},
-        415: {"description": "Unsupported file type"},
-    },
+    summary="Create a document and obtain upload URLs",
 )
-async def upload_document(
-    file: UploadFile = File(
-        ..., description="PDF, JPEG, PNG, or plain text. Max 10 MB."
-    ),
+def create_document(
+    payload: CreateDocumentRequest,
     user: dict = Depends(get_current_user),
-) -> UploadDocumentResponse:
-    """Accept a document upload and create a tracking record in Firestore.
+    idempotency_key: Annotated[
+        str | None,
+        Header(
+            alias="Idempotency-Key",
+            description=(
+                "Client-generated unique key. Retries with the same key + same uid "
+                "return the original document instead of creating a duplicate. "
+                "Stored for 24h."
+            ),
+            max_length=128,
+        ),
+    ] = None,
+) -> CreateDocumentResponse:
+    """Atomically create a Document plus a per-file record for each declared
+    file, returning a signed PUT URL for each.
 
-    The bytes are not yet persisted to GCS — that is a follow-up step. A Firestore
-    document is created in PENDING_UPLOAD state so the rest of the pipeline (and
-    the mobile client) has a stable id to refer to.
+    The client uploads each file directly to GCS using the returned URLs +
+    headers, then calls POST /documents/{document_id}/finalize.
     """
-    if file.content_type not in _ALLOWED_TYPES:
-        raise HTTPException(
-            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail=f"File type '{file.content_type}' is not allowed.",
-        )
+    _enforce_total_size(payload.files)
 
-    # TODO(streaming): reading the entire body into memory is not safe for
-    # large uploads. Switch to a streaming size validator before raising the
-    # 10 MB cap.
-    contents = await file.read()
-    if len(contents) > _MAX_SIZE_BYTES:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"File exceeds {_MAX_SIZE_BYTES // (1024 * 1024)} MB limit.",
-        )
+    uid = user["uid"]
 
-    # TODO(idempotency): a client retry will create duplicate records. Wire an
-    # Idempotency-Key header from mobile and dedupe on it before this insert.
-    # TODO(domain): currently hardcoded; pull from the request body once mobile
-    # sends it. Domain-configurability is the load-bearing requirement of the project.
-    document = create_document(
-        uid=user["uid"],
-        file_name=file.filename or "unknown",
-        content_type=file.content_type,
-        size_bytes=len(contents),
-        domain="medical",
+    # Idempotency short-circuit: if the same (uid, key) already created a
+    # document, return it (with fresh signed URLs for any pending files) rather
+    # than creating a duplicate.
+    if idempotency_key:
+        existing = find_document_by_idempotency_key(uid, idempotency_key)
+        if existing is not None:
+            return _create_response_from_existing(existing)
+
+    document = create_document_with_files(
+        uid=uid,
+        domain=payload.domain,
+        title=payload.title,
+        file_specs=[
+            FileCreationSpec(
+                file_name=f.file_name,
+                content_type=f.content_type,
+                size_bytes=f.size_bytes,
+            )
+            for f in payload.files
+        ],
+        idempotency_key=idempotency_key,
+        # Repository mints the document_id then calls back with it so we can
+        # compose the full GCS object path here without knowing the id upfront.
+        object_path_builder=lambda *, document_id, file_id, extension: gcs.build_object_path(
+            uid=uid,
+            document_id=document_id,
+            file_id=file_id,
+            extension=extension,
+        ),
     )
 
-    # TODO(gcs): upload bytes to GCS and update the Firestore record with
-    # gcs_uri + status=UPLOADED.
-    # TODO(pubsub): publish a DocumentUploaded event so the ingestion worker
-    # can pick this up.
-
-    return UploadDocumentResponse(
+    return CreateDocumentResponse(
         document_id=document.id,
         status=document.status,
-        file_name=document.file_name,
-        size_bytes=document.size_bytes,
+        domain=document.domain,
+        title=document.title,
+        file_count=document.file_count,
+        total_bytes=document.total_bytes,
+        files=[_make_upload_instruction(f) for f in document.files],
+        created_at=document.created_at,
     )
+
+
+def _create_response_from_existing(document: Document) -> CreateDocumentResponse:
+    """For idempotent retries: return the previously-created document with
+    fresh signed URLs for any files that have not yet been uploaded."""
+    instructions = [
+        _make_upload_instruction(f)
+        for f in document.files
+        if f.upload_completed_at is None
+    ]
+    return CreateDocumentResponse(
+        document_id=document.id,
+        status=document.status,
+        domain=document.domain,
+        title=document.title,
+        file_count=document.file_count,
+        total_bytes=document.total_bytes,
+        files=instructions,
+        created_at=document.created_at,
+    )
+
+
+@app.post(
+    "/documents/{document_id}/finalize",
+    response_model=DocumentResponse,
+    tags=["Documents"],
+    summary="Finalize a pending document after uploading files to GCS",
+)
+async def finalize_document(
+    document_id: str,
+    user: dict = Depends(get_current_user),
+) -> DocumentResponse:
+    """Verify uploaded files exist in GCS, transition status to `uploaded`, and
+    publish a DocumentUploaded event for the worker to pick up."""
+    uid = user["uid"]
+
+    document = find_document_for_user(document_id, uid)
+    if document is None:
+        raise APIError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code=ErrorCode.DOCUMENT_NOT_FOUND,
+            message="Document not found.",
+        )
+    if document.status is not DocumentStatus.PENDING_UPLOAD:
+        raise APIError(
+            status_code=status.HTTP_409_CONFLICT,
+            code=ErrorCode.DOCUMENT_ALREADY_FINALIZED,
+            message=f"document is in state {document.status.value}",
+        )
+
+    # Verify all files exist in GCS in parallel. Tolerates partial uploads —
+    # only the files that actually landed get marked uploaded.
+    existence = await asyncio.gather(
+        *(gcs.verify_object_exists(f.gcs_object_path) for f in document.files)
+    )
+    uploaded_ids = [f.file_id for f, ok in zip(document.files, existence) if ok]
+
+    if not uploaded_ids:
+        raise APIError(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code=ErrorCode.NO_FILES_UPLOADED,
+            message="No files were uploaded to GCS for this document.",
+        )
+
+    try:
+        document = mark_uploaded(document_id, uid, uploaded_ids)
+    except LookupError:
+        raise APIError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code=ErrorCode.DOCUMENT_NOT_FOUND,
+            message="Document not found.",
+        )
+    except DocumentStateError as exc:
+        raise APIError(
+            status_code=status.HTTP_409_CONFLICT,
+            code=ErrorCode.DOCUMENT_ALREADY_FINALIZED,
+            message=str(exc),
+        )
+
+    # Publish AFTER Firestore commit. If publish fails the document is still
+    # marked uploaded — a reconciliation job re-publishes stale `uploaded`
+    # documents that have no corresponding worker activity within N minutes.
+    try:
+        pubsub.publish_document_uploaded(document)
+    except Exception as exc:
+        _log.error(
+            "pubsub_publish_failed document_id=%s error=%s",
+            document_id, exc,
+        )
+
+    return _to_document_response(document)
+
+
+@app.post(
+    "/documents/{document_id}/upload-urls/refresh",
+    response_model=RefreshUploadURLsResponse,
+    tags=["Documents"],
+    summary="Reissue signed URLs for files that have not been uploaded yet",
+)
+def refresh_upload_urls(
+    document_id: str,
+    user: dict = Depends(get_current_user),
+) -> RefreshUploadURLsResponse:
+    """Replace expired signed URLs without losing the document.
+
+    Useful when a long-paused mobile upload outlives the URL TTL. Only files
+    without an `upload_completed_at` get fresh URLs; already-uploaded files
+    return nothing because they're write-once.
+    """
+    document = find_document_for_user(document_id, user["uid"])
+    if document is None:
+        raise APIError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code=ErrorCode.DOCUMENT_NOT_FOUND,
+            message="Document not found.",
+        )
+    if document.status is not DocumentStatus.PENDING_UPLOAD:
+        raise APIError(
+            status_code=status.HTTP_409_CONFLICT,
+            code=ErrorCode.DOCUMENT_ALREADY_FINALIZED,
+            message=f"document is in state {document.status.value}",
+        )
+    return RefreshUploadURLsResponse(
+        document_id=document.id,
+        status=document.status,
+        files=[_make_upload_instruction(f) for f in pending_files(document)],
+    )
+
+
+@app.get(
+    "/documents",
+    response_model=ListDocumentsResponse,
+    tags=["Documents"],
+    summary="List the current user's documents (paginated, filterable)",
+)
+def list_documents(
+    user: dict = Depends(get_current_user),
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    cursor: str | None = None,
+    domain: str | None = None,
+    status_filter: Annotated[DocumentStatus | None, Query(alias="status")] = None,
+) -> ListDocumentsResponse:
+    """Paginated list of documents newest-first.
+
+    Filters: `domain` (medical, finance, ...), `status` (any DocumentStatus
+    value). Cursor is opaque; clients pass back whatever `next_cursor` was
+    returned in the previous response.
+    """
+    if domain is not None and domain not in SUPPORTED_DOMAINS:
+        raise APIError(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            code=ErrorCode.INVALID_DOMAIN,
+            message=f"unsupported domain {domain!r}",
+        )
+
+    if cursor is not None:
+        try:
+            decode_cursor(cursor)
+        except ValueError:
+            raise APIError(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                code=ErrorCode.INVALID_PAGINATION_CURSOR,
+                message="cursor is malformed",
+            )
+
+    documents, next_cursor = list_documents_for_user(
+        user["uid"],
+        domain=domain,
+        status=status_filter,
+        limit=limit,
+        cursor=cursor,
+    )
+    return ListDocumentsResponse(
+        documents=[_to_list_item(d) for d in documents],
+        next_cursor=next_cursor,
+    )
+
+
+@app.get(
+    "/documents/{document_id}",
+    response_model=DocumentResponse,
+    tags=["Documents"],
+    summary="Read a single document, including signed download URLs for files",
+)
+def get_document(
+    document_id: str,
+    user: dict = Depends(get_current_user),
+) -> DocumentResponse:
+    document = find_document_for_user(document_id, user["uid"])
+    if document is None:
+        raise APIError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code=ErrorCode.DOCUMENT_NOT_FOUND,
+            message="Document not found.",
+        )
+    return _to_document_response(document)
+
+
+@app.delete(
+    "/documents/{document_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["Documents"],
+    summary="Soft-delete a document",
+)
+def delete_document(
+    document_id: str,
+    user: dict = Depends(get_current_user),
+) -> None:
+    """Mark the document as deleted. Refuses if a worker is mid-processing —
+    callers should poll until status leaves `processing` before retrying."""
+    try:
+        soft_delete(document_id, user["uid"])
+    except LookupError:
+        raise APIError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code=ErrorCode.DOCUMENT_NOT_FOUND,
+            message="Document not found.",
+        )
+    except DocumentStateError:
+        raise APIError(
+            status_code=status.HTTP_409_CONFLICT,
+            code=ErrorCode.DOCUMENT_IN_PROCESSING,
+            message="document is currently being processed; try again shortly",
+        )
 
 
 # ──────────────────────────────────────────────────────────────────────────────
 # OpenAPI customisation
 # ──────────────────────────────────────────────────────────────────────────────
 
-# FastAPI auto-generates an OpenAPI schema and emits a `HTTPBearer` security scheme
-# whenever a route uses `Depends(HTTPBearer())` — which `get_current_user` does.
-# We just decorate the auto-generated entry with `bearerFormat` and a description so
-# the Swagger UI Authorize dialog shows useful guidance. Replacing the scheme outright
-# would break the per-endpoint `security` references FastAPI already wired up.
 def custom_openapi():
+    """Decorate FastAPI's auto-generated HTTPBearer scheme with description and
+    bearer format so Swagger UI's Authorize dialog is useful."""
     if app.openapi_schema:
         return app.openapi_schema
 

--- a/Backend/api/middleware.py
+++ b/Backend/api/middleware.py
@@ -63,6 +63,18 @@ class RequestIDMiddleware:
         incoming = _read_incoming_header(scope)
         request_id = incoming[:64] if incoming else _generate_request_id()
 
+        # FastAPI routes the bare `Exception` / 500 handler through Starlette's
+        # ServerErrorMiddleware, which is the *outermost* middleware — outside
+        # this one. When an unhandled exception escapes, our `finally` resets
+        # the contextvar before that handler runs, so the contextvar is empty
+        # by the time the handler builds the response body. ASGI scope state
+        # is the right channel here: it survives the entire request lifecycle
+        # regardless of middleware structure, and `request.state` reads from
+        # it. Set it before any downstream code runs.
+        if "state" not in scope:
+            scope["state"] = {}
+        scope["state"]["request_id"] = request_id
+
         async def send_with_header(message):
             if message["type"] == "http.response.start":
                 # Defensively drop any pre-existing header so ours wins.

--- a/Backend/api/middleware.py
+++ b/Backend/api/middleware.py
@@ -1,0 +1,71 @@
+"""
+Request-ID propagation.
+
+Every inbound request gets a unique id, exposed back to the client via the
+`X-Request-ID` response header and stored in a `contextvars.ContextVar` so any
+log line emitted while handling the request includes it automatically.
+
+This is the seam that turns a user complaint ("upload failed at 14:23") into
+exact log lines: client gets the request id in the response, sends it to
+support, support greps the logs for it.
+"""
+
+import contextvars
+import logging
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+
+# Empty default so log records emitted outside a request (startup, scheduled
+# tasks) still serialize cleanly instead of raising KeyError.
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "request_id", default=""
+)
+
+
+_HEADER = "X-Request-ID"
+
+
+def _generate_request_id() -> str:
+    # 16 hex chars is plenty for human grep-ability without bloating log lines.
+    return f"req_{uuid.uuid4().hex[:16]}"
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Honor a client-supplied request id when present, else mint a new one.
+
+    A client sending its own id lets the mobile app correlate a network call
+    on its side with the matching server-side trace.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        incoming = request.headers.get(_HEADER, "").strip()
+        # Cap user-supplied ids to avoid log injection / pathological lengths.
+        request_id = incoming[:64] if incoming else _generate_request_id()
+
+        token = request_id_var.set(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+
+        response.headers[_HEADER] = request_id
+        return response
+
+
+class RequestIDLogFilter(logging.Filter):
+    """Inject the current request id into every log record.
+
+    Configure the root logger with this filter and `%(request_id)s` becomes
+    available in any log format string.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get("")
+        return True

--- a/Backend/api/middleware.py
+++ b/Backend/api/middleware.py
@@ -1,22 +1,24 @@
 """
 Request-ID propagation.
 
-Every inbound request gets a unique id, exposed back to the client via the
+Every inbound HTTP request gets a unique id, exposed back to the client via the
 `X-Request-ID` response header and stored in a `contextvars.ContextVar` so any
 log line emitted while handling the request includes it automatically.
 
-This is the seam that turns a user complaint ("upload failed at 14:23") into
-exact log lines: client gets the request id in the response, sends it to
-support, support greps the logs for it.
+Implemented as a pure ASGI middleware rather than Starlette's
+`BaseHTTPMiddleware`. `BaseHTTPMiddleware` runs the downstream app in a
+separate `asyncio` task, which breaks `ContextVar` inheritance into FastAPI's
+exception-handler scope — the symptom in production was `request_id: null` on
+500 responses. Pure ASGI wraps the entire request handling chain in one
+coroutine, so the contextvar set here is visible everywhere downstream,
+including in exception handlers.
 """
 
 import contextvars
 import logging
 import uuid
 
-from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 # Empty default so log records emitted outside a request (startup, scheduled
@@ -26,7 +28,7 @@ request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
 )
 
 
-_HEADER = "X-Request-ID"
+_HEADER_NAME = b"x-request-id"
 
 
 def _generate_request_id() -> str:
@@ -34,29 +36,50 @@ def _generate_request_id() -> str:
     return f"req_{uuid.uuid4().hex[:16]}"
 
 
-class RequestIDMiddleware(BaseHTTPMiddleware):
-    """Honor a client-supplied request id when present, else mint a new one.
+def _read_incoming_header(scope: Scope) -> str:
+    """Read a client-supplied X-Request-ID from the ASGI scope headers."""
+    for raw_name, raw_value in scope.get("headers", []):
+        if raw_name.lower() == _HEADER_NAME:
+            return raw_value.decode("latin-1", errors="ignore").strip()
+    return ""
 
-    A client sending its own id lets the mobile app correlate a network call
-    on its side with the matching server-side trace.
+
+class RequestIDMiddleware:
+    """Pure ASGI middleware that sets a per-request `X-Request-ID`.
+
+    Honors a client-supplied id (capped to 64 chars to prevent log injection
+    and pathological lengths), else mints one. The id is written into the
+    outgoing response headers and held in a `ContextVar` for the lifetime of
+    the request.
     """
 
     def __init__(self, app: ASGIApp) -> None:
-        super().__init__(app)
+        self.app = app
 
-    async def dispatch(self, request: Request, call_next):
-        incoming = request.headers.get(_HEADER, "").strip()
-        # Cap user-supplied ids to avoid log injection / pathological lengths.
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        incoming = _read_incoming_header(scope)
         request_id = incoming[:64] if incoming else _generate_request_id()
+
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                # Defensively drop any pre-existing header so ours wins.
+                headers = [
+                    (name, value)
+                    for name, value in message.get("headers", [])
+                    if name.lower() != _HEADER_NAME
+                ]
+                headers.append((_HEADER_NAME, request_id.encode("ascii")))
+                message["headers"] = headers
+            await send(message)
 
         token = request_id_var.set(request_id)
         try:
-            response = await call_next(request)
+            await self.app(scope, receive, send_with_header)
         finally:
             request_id_var.reset(token)
-
-        response.headers[_HEADER] = request_id
-        return response
 
 
 class RequestIDLogFilter(logging.Filter):

--- a/Backend/api/requirements.txt
+++ b/Backend/api/requirements.txt
@@ -4,3 +4,5 @@ firebase-admin==7.4.0
 python-multipart==0.0.27
 python-dotenv==1.0.1
 email-validator==2.2.0
+google-cloud-storage==2.18.2
+google-cloud-pubsub==2.27.1

--- a/Backend/api/requirements.txt
+++ b/Backend/api/requirements.txt
@@ -4,5 +4,5 @@ firebase-admin==7.4.0
 python-multipart==0.0.27
 python-dotenv==1.0.1
 email-validator==2.2.0
-google-cloud-storage==2.18.2
+google-cloud-storage==3.10.1
 google-cloud-pubsub==2.27.1

--- a/Backend/api/terraform/main.tf
+++ b/Backend/api/terraform/main.tf
@@ -3,6 +3,36 @@ provider "google" {
   region  = var.region
 }
 
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Required GCP APIs.
+#
+# Enabling them in terraform keeps fresh-project provisioning self-contained:
+# nothing has to be clicked in the console for a new environment to come up.
+# `disable_on_destroy = false` prevents `terraform destroy` from yanking the
+# API out from under sibling services that depend on it.
+# ──────────────────────────────────────────────────────────────────────────────
+
+locals {
+  required_apis = [
+    "run.googleapis.com",
+    "firestore.googleapis.com",
+    "storage.googleapis.com",
+    "pubsub.googleapis.com",
+    "identitytoolkit.googleapis.com",   # Firebase Auth (signup/signin)
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",    # v4 signed URLs without a private key
+  ]
+}
+
+resource "google_project_service" "apis" {
+  for_each = toset(local.required_apis)
+  service  = each.value
+
+  disable_on_destroy         = false
+  disable_dependent_services = false
+}
+
 # Local names referenced repeatedly. Keeping them as locals lets us rename in
 # one place if the team converges on a different convention later.
 locals {

--- a/Backend/api/terraform/main.tf
+++ b/Backend/api/terraform/main.tf
@@ -3,13 +3,140 @@ provider "google" {
   region  = var.region
 }
 
+# Local names referenced repeatedly. Keeping them as locals lets us rename in
+# one place if the team converges on a different convention later.
+locals {
+  bucket_name             = "ailixir-documents-${var.project_id}"
+  topic_uploaded          = "document-uploaded"
+  topic_uploaded_dlq      = "document-uploaded-dlq"
+  api_service_account_id  = "ailixir-api"
+}
 
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Service account the API runs as.
+#
+# Owns: signed-URL signing (Storage Object Admin + serviceAccountTokenCreator
+# on itself), event publishing (Pub/Sub Publisher), Firestore reads/writes
+# (Datastore User).
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "google_service_account" "api" {
+  account_id   = local.api_service_account_id
+  display_name = "Ailixir API service account"
+  description  = "Runs the documents API on Cloud Run."
+}
+
+# Grants the SA permission to mint OAuth tokens for itself, which the
+# google-cloud-storage library needs to call IAM Credentials API for signing
+# URLs without a private key file. Without this, v4 signed URLs fail on prod.
+resource "google_service_account_iam_member" "api_self_token_creator" {
+  service_account_id = google_service_account.api.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.api.email}"
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GCS bucket holding document files.
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "google_storage_bucket" "documents" {
+  name                        = local.bucket_name
+  location                    = var.region
+  uniform_bucket_level_access = true
+
+  # Refuse to destroy a non-empty bucket via `terraform destroy`. Production
+  # operators must explicitly empty the bucket first; this prevents the
+  # ultimate accidental data loss.
+  force_destroy = false
+
+  # Object versioning lets a recovery process restore a file that was
+  # accidentally overwritten. We separately enforce x-goog-if-generation-match=0
+  # at the API layer so legitimate uploads never overwrite.
+  versioning {
+    enabled = true
+  }
+
+  # Reap noncurrent (versioned) objects after 7 days. Combined with the API's
+  # write-once enforcement, this means deleted/replaced objects don't linger.
+  lifecycle_rule {
+    condition {
+      age        = 7
+      with_state = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # CORS for browser-based uploads (Swagger UI Try-It-Out, future web admin).
+  # React Native doesn't enforce CORS, so this is for dev tooling — keeping
+  # the allow-list tight to known dev origins until we add production ones.
+  cors {
+    origin          = ["http://localhost:3000", "http://localhost:8000", "http://127.0.0.1:8000"]
+    method          = ["GET", "PUT", "HEAD"]
+    response_header = ["Content-Type", "x-goog-content-length-range", "x-goog-if-generation-match"]
+    max_age_seconds = 3600
+  }
+}
+
+resource "google_storage_bucket_iam_member" "api_documents_admin" {
+  bucket = google_storage_bucket.documents.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.api.email}"
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pub/Sub: DocumentUploaded topic and DLQ.
+#
+# Subscription resource lives in workers/terraform/ (owned by the consumer).
+# The API publishes here by name; cross-state references aren't needed because
+# Pub/Sub topic names are stable identifiers.
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "google_pubsub_topic" "document_uploaded" {
+  name                       = local.topic_uploaded
+  message_retention_duration = "604800s"  # 7 days
+}
+
+resource "google_pubsub_topic" "document_uploaded_dlq" {
+  name                       = local.topic_uploaded_dlq
+  message_retention_duration = "604800s"
+}
+
+resource "google_pubsub_topic_iam_member" "api_publisher" {
+  topic  = google_pubsub_topic.document_uploaded.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.api.email}"
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Firestore access for the API. Datastore User covers read + write on
+# documents within the user's own namespace; security rules (when added) will
+# enforce per-uid isolation.
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "google_project_iam_member" "api_firestore_user" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.api.email}"
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Cloud Run API service.
+# ──────────────────────────────────────────────────────────────────────────────
 
 resource "google_cloud_run_v2_service" "backend" {
   name     = "ailixir-backend"
   location = var.region
 
   template {
+    service_account = google_service_account.api.email
+
     containers {
       image = "gcr.io/${var.project_id}/ailixir-backend:${var.image_tag}"
 
@@ -21,8 +148,34 @@ resource "google_cloud_run_v2_service" "backend" {
         name  = "GCP_PROJECT_ID"
         value = var.project_id
       }
+      env {
+        name  = "FIREBASE_PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "GCS_BUCKET_NAME"
+        value = google_storage_bucket.documents.name
+      }
+      env {
+        name  = "PUBSUB_TOPIC_DOCUMENT_UPLOADED"
+        value = google_pubsub_topic.document_uploaded.name
+      }
+      # Empty value forces shared/firestore.py and shared/gcs.py to fall back
+      # to Application Default Credentials (the metadata server on Cloud Run).
+      env {
+        name  = "FIREBASE_KEY_RELATIVE_PATH"
+        value = ""
+      }
     }
   }
+
+  # Ensure IAM bindings exist before the service tries to use them on cold start.
+  depends_on = [
+    google_service_account_iam_member.api_self_token_creator,
+    google_storage_bucket_iam_member.api_documents_admin,
+    google_pubsub_topic_iam_member.api_publisher,
+    google_project_iam_member.api_firestore_user,
+  ]
 }
 
 resource "google_cloud_run_v2_service_iam_member" "backend_public" {
@@ -32,6 +185,27 @@ resource "google_cloud_run_v2_service_iam_member" "backend_public" {
   member   = "allUsers"
 }
 
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Outputs.
+# ──────────────────────────────────────────────────────────────────────────────
+
 output "backend_url" {
   value = google_cloud_run_v2_service.backend.uri
+}
+
+output "documents_bucket" {
+  value = google_storage_bucket.documents.name
+}
+
+output "topic_document_uploaded" {
+  value = google_pubsub_topic.document_uploaded.name
+}
+
+output "topic_document_uploaded_dlq" {
+  value = google_pubsub_topic.document_uploaded_dlq.name
+}
+
+output "api_service_account_email" {
+  value = google_service_account.api.email
 }

--- a/Backend/api/terraform/main.tf
+++ b/Backend/api/terraform/main.tf
@@ -125,6 +125,15 @@ resource "google_project_iam_member" "api_firestore_user" {
   member  = "serviceAccount:${google_service_account.api.email}"
 }
 
+# Firebase Auth admin: required for the /auth/signup endpoint, which calls
+# firebase_admin.auth.create_user under the hood. Without this, every signup
+# request fails with a permission-denied error wrapped in a generic 500.
+resource "google_project_iam_member" "api_firebase_auth_admin" {
+  project = var.project_id
+  role    = "roles/firebaseauth.admin"
+  member  = "serviceAccount:${google_service_account.api.email}"
+}
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Cloud Run API service.
@@ -175,6 +184,7 @@ resource "google_cloud_run_v2_service" "backend" {
     google_storage_bucket_iam_member.api_documents_admin,
     google_pubsub_topic_iam_member.api_publisher,
     google_project_iam_member.api_firestore_user,
+    google_project_iam_member.api_firebase_auth_admin,
   ]
 }
 

--- a/Backend/firestore.indexes.json
+++ b/Backend/firestore.indexes.json
@@ -1,0 +1,57 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "uid",        "order": "ASCENDING" },
+        { "fieldPath": "deleted_at", "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" },
+        { "fieldPath": "id",         "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "uid",        "order": "ASCENDING" },
+        { "fieldPath": "deleted_at", "order": "ASCENDING" },
+        { "fieldPath": "domain",     "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" },
+        { "fieldPath": "id",         "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "uid",        "order": "ASCENDING" },
+        { "fieldPath": "deleted_at", "order": "ASCENDING" },
+        { "fieldPath": "status",     "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" },
+        { "fieldPath": "id",         "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "uid",        "order": "ASCENDING" },
+        { "fieldPath": "deleted_at", "order": "ASCENDING" },
+        { "fieldPath": "domain",     "order": "ASCENDING" },
+        { "fieldPath": "status",     "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" },
+        { "fieldPath": "id",         "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "uid",             "order": "ASCENDING" },
+        { "fieldPath": "idempotency_key", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/Backend/shared/firestore.py
+++ b/Backend/shared/firestore.py
@@ -51,15 +51,26 @@ def ensure_firebase_app() -> None:
         if _emulator_mode():
             firebase_admin.initialize_app(options={"projectId": _PROJECT_ID})
             return
-        if _KEY_PATH.exists():
-            cred = credentials.Certificate(str(_KEY_PATH))
-            firebase_admin.initialize_app(cred)
+
+        # Empty env var is the explicit opt-in to Application Default
+        # Credentials — the production / Cloud Run path, where the metadata
+        # server supplies the runtime service account.
+        if not _KEY_RELATIVE_PATH:
+            firebase_admin.initialize_app(options={"projectId": _PROJECT_ID})
             return
-        # Production / Cloud Run: no JSON key on disk. Fall back to Application
-        # Default Credentials, which pick up the runtime service account from
-        # the metadata server. The project id must still be supplied explicitly
-        # because ADC alone doesn't carry it.
-        firebase_admin.initialize_app(options={"projectId": _PROJECT_ID})
+
+        # Env var set but pointing at nothing is almost always a typo. Fail
+        # loudly with the resolved path so the operator can fix it, rather
+        # than silently degrading to ADC and confusing the next bug report.
+        if not _KEY_PATH.is_file():
+            raise FileNotFoundError(
+                f"Firebase credentials file not found at {_KEY_PATH}.\n"
+                f"Set FIREBASE_KEY_RELATIVE_PATH to a valid file, "
+                f"or leave it empty to use Application Default Credentials."
+            )
+
+        cred = credentials.Certificate(str(_KEY_PATH))
+        firebase_admin.initialize_app(cred)
 
 
 def get_firestore() -> Client:

--- a/Backend/shared/firestore.py
+++ b/Backend/shared/firestore.py
@@ -51,16 +51,15 @@ def ensure_firebase_app() -> None:
         if _emulator_mode():
             firebase_admin.initialize_app(options={"projectId": _PROJECT_ID})
             return
-        if not _KEY_PATH.exists():
-            raise FileNotFoundError(
-                f"Firebase service account key not found.\n"
-                f"  Expected at: {_KEY_PATH}\n"
-                f"  Backend root: {BACKEND_ROOT}\n"
-                f"  Relative path: {_KEY_RELATIVE_PATH}\n"
-                f"Set FIREBASE_KEY_RELATIVE_PATH to override the default location."
-            )
-        cred = credentials.Certificate(str(_KEY_PATH))
-        firebase_admin.initialize_app(cred)
+        if _KEY_PATH.exists():
+            cred = credentials.Certificate(str(_KEY_PATH))
+            firebase_admin.initialize_app(cred)
+            return
+        # Production / Cloud Run: no JSON key on disk. Fall back to Application
+        # Default Credentials, which pick up the runtime service account from
+        # the metadata server. The project id must still be supplied explicitly
+        # because ADC alone doesn't carry it.
+        firebase_admin.initialize_app(options={"projectId": _PROJECT_ID})
 
 
 def get_firestore() -> Client:

--- a/Backend/shared/gcs.py
+++ b/Backend/shared/gcs.py
@@ -51,12 +51,25 @@ _client: storage.Client | None = None
 
 
 def _init_client() -> storage.Client:
-    """Create the GCS client once, using the same JSON key as Firebase if
-    available, otherwise the metadata-server default credentials."""
-    if _KEY_PATH.exists():
-        return storage.Client.from_service_account_json(str(_KEY_PATH))
-    # On Cloud Run / GKE the metadata server supplies credentials automatically.
-    return storage.Client()
+    """Create the GCS client once.
+
+    Three distinct paths matching `shared/firestore.py`:
+      - empty env var → Application Default Credentials (Cloud Run path)
+      - non-empty + valid file → load JSON key
+      - non-empty + missing file → fail loudly (a typo masquerading as ADC
+        intent is a real production hazard)
+    """
+    if not _KEY_RELATIVE_PATH:
+        return storage.Client()
+
+    if not _KEY_PATH.is_file():
+        raise FileNotFoundError(
+            f"Firebase credentials file not found at {_KEY_PATH}.\n"
+            f"Set FIREBASE_KEY_RELATIVE_PATH to a valid file, "
+            f"or leave it empty to use Application Default Credentials."
+        )
+
+    return storage.Client.from_service_account_json(str(_KEY_PATH))
 
 
 def get_storage_client() -> storage.Client:

--- a/Backend/shared/gcs.py
+++ b/Backend/shared/gcs.py
@@ -1,0 +1,175 @@
+"""
+Google Cloud Storage client and signed URL helpers.
+
+The API never streams file bytes through itself. Clients receive time-limited
+v4 signed URLs and upload directly to GCS, which keeps the API stateless and
+its bandwidth bill bounded.
+
+Two signing modes are supported transparently:
+
+  - Local development: credentials loaded from a service-account JSON key.
+    The private key is available in-process, so URLs are signed locally with no
+    extra network call.
+
+  - Production on Cloud Run: the service runs as a Google-managed service
+    account with no private key. Signing falls back to the IAM Credentials API,
+    which requires the service account to hold `iam.serviceAccountTokenCreator`
+    on itself (configured in terraform).
+"""
+
+import asyncio
+import logging
+import os
+import threading
+from datetime import timedelta
+from pathlib import Path
+
+from google.auth.transport.requests import Request as GoogleAuthRequest
+from google.cloud import storage
+from google.oauth2 import service_account
+
+_log = logging.getLogger(__name__)
+
+# Repo layout: Backend/shared/gcs.py → Backend root is two levels up.
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+_BUCKET_NAME = os.getenv("GCS_BUCKET_NAME", "ailixir-documents-amos26")
+_KEY_RELATIVE_PATH = os.getenv(
+    "FIREBASE_KEY_RELATIVE_PATH",
+    "secrets/serviceAccountKey.json",
+)
+_KEY_PATH = BACKEND_ROOT / _KEY_RELATIVE_PATH
+
+# How long signed URLs (upload + download) remain valid. Short enough to limit
+# blast radius if a URL leaks; long enough to tolerate slow mobile networks.
+DEFAULT_SIGNED_URL_TTL = timedelta(
+    seconds=int(os.getenv("GCS_SIGNED_URL_TTL_SECONDS", "900"))
+)
+
+_init_lock = threading.Lock()
+_client: storage.Client | None = None
+
+
+def _init_client() -> storage.Client:
+    """Create the GCS client once, using the same JSON key as Firebase if
+    available, otherwise the metadata-server default credentials."""
+    if _KEY_PATH.exists():
+        return storage.Client.from_service_account_json(str(_KEY_PATH))
+    # On Cloud Run / GKE the metadata server supplies credentials automatically.
+    return storage.Client()
+
+
+def get_storage_client() -> storage.Client:
+    """Return the singleton GCS client. Initialised lazily on first call."""
+    global _client
+    if _client is not None:
+        return _client
+    with _init_lock:
+        if _client is None:
+            _client = _init_client()
+    return _client
+
+
+def get_bucket() -> storage.Bucket:
+    return get_storage_client().bucket(_BUCKET_NAME)
+
+
+def build_object_path(*, uid: str, document_id: str, file_id: str, extension: str) -> str:
+    """Compose the canonical GCS object path for a document's file.
+
+    Layout: `users/{uid}/documents/{doc_id}/{file_id}.{ext}`. Per-user prefix
+    makes uid-scoped lifecycle policies and bulk deletion trivial.
+    """
+    return f"users/{uid}/documents/{document_id}/{file_id}.{extension}"
+
+
+def _signing_kwargs() -> dict:
+    """Return kwargs for `generate_signed_url` that route signing through the
+    IAM Credentials API when no local private key is available.
+
+    A `service_account.Credentials` instance (loaded from a JSON key) can sign
+    in-process and needs no extra kwargs. Any other credentials object — most
+    notably the Cloud Run default SA — must sign via IAM Credentials, which
+    requires both `service_account_email` and a refreshed `access_token`.
+    """
+    creds = get_storage_client()._credentials
+    if isinstance(creds, service_account.Credentials):
+        return {}
+
+    if not creds.valid:
+        creds.refresh(GoogleAuthRequest())
+
+    return {
+        "service_account_email": creds.service_account_email,
+        "access_token": creds.token,
+    }
+
+
+def generate_upload_url(
+    *,
+    object_path: str,
+    content_type: str,
+    max_size_bytes: int,
+    ttl: timedelta = DEFAULT_SIGNED_URL_TTL,
+) -> str:
+    """Generate a v4 PUT signed URL bound to a specific object path.
+
+    The returned URL imposes three constraints the client cannot work around:
+
+      - `Content-Type` must match `content_type` exactly.
+      - Body size must be within `0..max_size_bytes` (enforced server-side by
+        GCS via `x-goog-content-length-range`).
+      - The object must not already exist (`x-goog-if-generation-match: 0`).
+        This makes the upload effectively write-once and prevents a malicious
+        client from overwriting their own document's files after finalize.
+    """
+    blob = get_bucket().blob(object_path)
+    return blob.generate_signed_url(
+        version="v4",
+        expiration=ttl,
+        method="PUT",
+        content_type=content_type,
+        headers={
+            "x-goog-content-length-range": f"0,{max_size_bytes}",
+            "x-goog-if-generation-match": "0",
+        },
+        **_signing_kwargs(),
+    )
+
+
+def generate_download_url(
+    *,
+    object_path: str,
+    ttl: timedelta = DEFAULT_SIGNED_URL_TTL,
+) -> str:
+    """Generate a v4 GET signed URL for an existing object."""
+    blob = get_bucket().blob(object_path)
+    return blob.generate_signed_url(
+        version="v4",
+        expiration=ttl,
+        method="GET",
+        **_signing_kwargs(),
+    )
+
+
+async def verify_object_exists(object_path: str) -> bool:
+    """Async HEAD check on a GCS object.
+
+    Wraps the synchronous `blob.exists()` in a thread so callers can issue
+    many checks concurrently via `asyncio.gather`, which is what `finalize`
+    relies on for documents with multiple files.
+    """
+    def _check() -> bool:
+        return get_bucket().blob(object_path).exists()
+    return await asyncio.to_thread(_check)
+
+
+def delete_object(object_path: str) -> None:
+    """Delete a single object. Idempotent: missing objects return silently."""
+    blob = get_bucket().blob(object_path)
+    try:
+        blob.delete()
+    except Exception as exc:
+        # The reconciliation job is the authoritative cleaner; the API never
+        # blocks user-facing operations on GCS delete success.
+        _log.warning("gcs_delete_failed path=%s error=%s", object_path, exc)

--- a/Backend/shared/gcs.py
+++ b/Backend/shared/gcs.py
@@ -24,9 +24,17 @@ import threading
 from datetime import timedelta
 from pathlib import Path
 
+import google.auth
+from google.auth.credentials import Credentials
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.cloud import storage
 from google.oauth2 import service_account
+
+
+# IAM Credentials' SignBlob endpoint requires this scope. The storage client
+# requests narrower devstorage.* scopes for its own calls, so we maintain a
+# separate credentials object specifically for v4 URL signing.
+_SIGNING_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
 
 _log = logging.getLogger(__name__)
 
@@ -48,6 +56,8 @@ DEFAULT_SIGNED_URL_TTL = timedelta(
 
 _init_lock = threading.Lock()
 _client: storage.Client | None = None
+_signing_creds: Credentials | None = None
+_signing_init_lock = threading.Lock()
 
 
 def _init_client() -> storage.Client:
@@ -96,16 +106,46 @@ def build_object_path(*, uid: str, document_id: str, file_id: str, extension: st
     return f"users/{uid}/documents/{document_id}/{file_id}.{extension}"
 
 
-def _signing_kwargs() -> dict:
-    """Return kwargs for `generate_signed_url` that route signing through the
-    IAM Credentials API when no local private key is available.
+def _get_signing_credentials() -> Credentials:
+    """Resolve a credentials object suitable for v4 URL signing.
 
-    A `service_account.Credentials` instance (loaded from a JSON key) can sign
-    in-process and needs no extra kwargs. Any other credentials object — most
-    notably the Cloud Run default SA — must sign via IAM Credentials, which
-    requires both `service_account_email` and a refreshed `access_token`.
+    Important: the storage client's own credentials are scoped to `devstorage.*`,
+    which is sufficient for object operations but NOT for IAM Credentials'
+    SignBlob call. Reusing them produces `ACCESS_TOKEN_SCOPE_INSUFFICIENT` 403s
+    in production. We maintain a separate credentials object explicitly scoped
+    to `cloud-platform` for signing.
     """
-    creds = get_storage_client()._credentials
+    global _signing_creds
+    if _signing_creds is not None:
+        return _signing_creds
+    with _signing_init_lock:
+        if _signing_creds is not None:
+            return _signing_creds
+
+        if _KEY_RELATIVE_PATH and _KEY_PATH.is_file():
+            # JSON service account key: returns service_account.Credentials,
+            # which has a local private signer and never needs IAM Credentials.
+            _signing_creds = service_account.Credentials.from_service_account_file(
+                str(_KEY_PATH),
+                scopes=list(_SIGNING_SCOPES),
+            )
+        else:
+            # ADC path (Cloud Run): request the cloud-platform scope explicitly
+            # so the metadata-server token can satisfy IAM Credentials.SignBlob.
+            creds, _ = google.auth.default(scopes=list(_SIGNING_SCOPES))
+            _signing_creds = creds
+
+    return _signing_creds
+
+
+def _signing_kwargs() -> dict:
+    """Return kwargs for `generate_signed_url`.
+
+    Service-account-with-private-key: sign in-process, no kwargs needed.
+    Compute-engine ADC: pass `service_account_email` + a freshly-refreshed
+    `access_token` so the library uses IAM Credentials' SignBlob.
+    """
+    creds = _get_signing_credentials()
     if isinstance(creds, service_account.Credentials):
         return {}
 

--- a/Backend/shared/models/document.py
+++ b/Backend/shared/models/document.py
@@ -1,21 +1,55 @@
 """
-Domain model for an uploaded document and its lifecycle status.
+Domain model for an uploaded document and its files.
 
-A `Document` is a row in the `documents` Firestore collection. The same shape is
-used by the API (writes), the ingestion worker (status updates), and any future
-service that reads document state.
+A `Document` is one logical user upload (e.g. a multi-page blood report). It
+owns an array of `DocumentFile` entries — one per physical file (each page of a
+scanned PDF, each PNG from a phone camera burst).
+
+The same shapes are used by the API (creates, reads), the ingestion worker
+(status transitions), and any future service that reads document state.
 """
 
 from datetime import datetime
 from enum import Enum
+from typing import ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+
+
+# Domains the API will accept at create time. Sourced here as a constant for PR 1;
+# eventually replaced by a runtime lookup against the domain-config service so
+# adding a new domain stays a YAML-only change.
+# TODO(domain-config): wire this to the domain-config service when it lands.
+SUPPORTED_DOMAINS: frozenset[str] = frozenset({"medical", "finance"})
+
+
+# Content types the API accepts for document files. Anything outside this set
+# is rejected before any GCS work happens.
+ALLOWED_FILE_CONTENT_TYPES: frozenset[str] = frozenset(
+    {"image/png", "image/jpeg", "application/pdf"}
+)
+
+
+# Map content type to the file extension we store in GCS. Keeps the storage
+# layout self-describing without trusting client-supplied extensions.
+EXTENSION_BY_CONTENT_TYPE: dict[str, str] = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "application/pdf": "pdf",
+}
+
+
+# Hard caps. These are defensive limits, not product policy — protect Cloud Run
+# from runaway requests. Real per-user quotas belong in a future ticket.
+MAX_FILES_PER_DOCUMENT: int = 50
+MAX_FILE_SIZE_BYTES: int = 20 * 1024 * 1024  # 20 MB per file
+MAX_TOTAL_SIZE_BYTES: int = 200 * 1024 * 1024  # 200 MB per document
 
 
 class DocumentStatus(str, Enum):
-    """Lifecycle states for an uploaded document.
+    """Lifecycle of a document.
 
-    Forward path: PENDING_UPLOAD → UPLOADED → PROCESSING → EXTRACTED.
+    Forward: PENDING_UPLOAD → UPLOADED → PROCESSING → EXTRACTED.
     From any state the document may transition to FAILED, which is terminal.
     """
 
@@ -26,15 +60,46 @@ class DocumentStatus(str, Enum):
     FAILED = "failed"
 
 
-class Document(BaseModel):
-    id: str
-    uid: str
+class DocumentFile(BaseModel):
+    """One physical file inside a Document."""
+
+    file_id: str
     file_name: str
     content_type: str
     size_bytes: int
+    gcs_object_path: str
+    # Set by finalize once the API verifies the upload landed in GCS. Until
+    # then, this file is conceptually still pending.
+    upload_completed_at: datetime | None = None
+
+
+class Document(BaseModel):
+    """A user-owned logical document plus its files."""
+
+    # `extra=ignore` lets us deserialize older Firestore records that lack
+    # fields added by later schema changes (forward/backward compat).
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
+
+    id: str
+    uid: str
     domain: str
+    title: str | None
     status: DocumentStatus
-    gcs_uri: str | None = None
+    files: list[DocumentFile]
+    file_count: int
+    total_bytes: int
+
+    # Per-uid idempotency key (SHA-256 hash of the client header). Used to
+    # short-circuit retried POST /documents calls into returning the original
+    # document rather than creating a duplicate.
+    idempotency_key: str | None = None
+
     created_at: datetime
     updated_at: datetime
+    # Set when status transitions to UPLOADED.
+    finalized_at: datetime | None = None
+    # Soft-delete marker. Reads filter on this; a background job hard-deletes
+    # after retention.
+    deleted_at: datetime | None = None
+    # Populated when status transitions to FAILED.
     error: str | None = None

--- a/Backend/shared/models/errors.py
+++ b/Backend/shared/models/errors.py
@@ -1,0 +1,52 @@
+"""
+Structured error responses for the API.
+
+Every HTTP error the API returns carries a stable `code` (suitable for client
+switch statements), a human-readable `message`, and the originating `request_id`
+so support requests can be traced back to exact log lines.
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class ErrorCode(str, Enum):
+    # Generic
+    INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
+    VALIDATION_FAILED = "VALIDATION_FAILED"
+
+    # Auth
+    UNAUTHENTICATED = "UNAUTHENTICATED"
+    TOKEN_EXPIRED = "TOKEN_EXPIRED"
+    TOKEN_REVOKED = "TOKEN_REVOKED"
+    INVALID_TOKEN = "INVALID_TOKEN"
+    USER_DISABLED = "USER_DISABLED"
+
+    # Users
+    USER_PROFILE_NOT_FOUND = "USER_PROFILE_NOT_FOUND"
+    EMAIL_ALREADY_EXISTS = "EMAIL_ALREADY_EXISTS"
+
+    # Documents
+    DOCUMENT_NOT_FOUND = "DOCUMENT_NOT_FOUND"
+    DOCUMENT_ALREADY_FINALIZED = "DOCUMENT_ALREADY_FINALIZED"
+    DOCUMENT_IN_PROCESSING = "DOCUMENT_IN_PROCESSING"
+    NO_FILES_UPLOADED = "NO_FILES_UPLOADED"
+    INVALID_DOMAIN = "INVALID_DOMAIN"
+    INVALID_FILE_TYPE = "INVALID_FILE_TYPE"
+    FILE_TOO_LARGE = "FILE_TOO_LARGE"
+    TOTAL_SIZE_EXCEEDED = "TOTAL_SIZE_EXCEEDED"
+    TOO_MANY_FILES = "TOO_MANY_FILES"
+    INVALID_FILE_NAME = "INVALID_FILE_NAME"
+    IDEMPOTENCY_KEY_REQUIRED = "IDEMPOTENCY_KEY_REQUIRED"
+    INVALID_PAGINATION_CURSOR = "INVALID_PAGINATION_CURSOR"
+
+
+class ErrorDetail(BaseModel):
+    code: ErrorCode
+    message: str
+    request_id: str | None = None
+
+
+class ErrorResponse(BaseModel):
+    error: ErrorDetail

--- a/Backend/shared/pubsub.py
+++ b/Backend/shared/pubsub.py
@@ -1,0 +1,112 @@
+"""
+Google Cloud Pub/Sub publisher and event helpers.
+
+The API publishes `DocumentUploaded` events after finalize so the worker can
+pick up OCR / extraction asynchronously. All publishes use `document_id` as
+the ordering key so per-document events stay sequenced (e.g. upload before any
+later delete or reprocess).
+"""
+
+import json
+import logging
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+
+from google.cloud import pubsub_v1
+
+from shared.models.document import Document
+
+_log = logging.getLogger(__name__)
+
+_PROJECT_ID = os.getenv("FIREBASE_PROJECT_ID", "amos26")
+_TOPIC_DOCUMENT_UPLOADED = os.getenv("PUBSUB_TOPIC_DOCUMENT_UPLOADED", "document-uploaded")
+
+# Schema version for event payloads. Bump when the event shape changes in a
+# way that downstream consumers must handle differently.
+EVENT_SCHEMA_VERSION = "v1"
+
+# Block until the publisher confirms delivery (or fails). Short enough to surface
+# real problems to the caller; long enough to ride out transient network blips.
+_PUBLISH_TIMEOUT_SECONDS = 30
+
+_init_lock = threading.Lock()
+_publisher: pubsub_v1.PublisherClient | None = None
+
+
+def _get_publisher() -> pubsub_v1.PublisherClient:
+    """Lazily initialise the Pub/Sub publisher with message ordering enabled.
+
+    Ordering must be enabled at the client level — it cannot be toggled per
+    publish call. The matching subscription side also needs ordering enabled
+    in terraform.
+    """
+    global _publisher
+    if _publisher is not None:
+        return _publisher
+    with _init_lock:
+        if _publisher is None:
+            _publisher = pubsub_v1.PublisherClient(
+                publisher_options=pubsub_v1.types.PublisherOptions(
+                    enable_message_ordering=True,
+                )
+            )
+    return _publisher
+
+
+def _topic_path(topic_name: str) -> str:
+    return _get_publisher().topic_path(_PROJECT_ID, topic_name)
+
+
+def publish_document_uploaded(document: Document) -> str:
+    """Publish a `DocumentUploaded` event and return the Pub/Sub message id.
+
+    The event payload includes only files whose upload was verified by finalize
+    — partially-uploaded documents emit an event reflecting just the present
+    files, not the originally-declared file count.
+
+    Raises whatever `Future.result` raises if the publish fails. Callers must
+    decide whether to retry (and risk duplicate delivery, which the worker
+    dedupes on `event_id`) or surface the error to the client.
+    """
+    publisher = _get_publisher()
+
+    event = {
+        "event_type": "DocumentUploaded",
+        "event_id": f"evt_{uuid.uuid4().hex}",
+        "schema_version": EVENT_SCHEMA_VERSION,
+        "occurred_at": datetime.now(timezone.utc).isoformat(),
+        "document_id": document.id,
+        "uid": document.uid,
+        "domain": document.domain,
+        "file_count": sum(1 for f in document.files if f.upload_completed_at is not None),
+        "files": [
+            {
+                "file_id": f.file_id,
+                "gcs_object_path": f.gcs_object_path,
+                "content_type": f.content_type,
+                "size_bytes": f.size_bytes,
+                "file_name": f.file_name,
+            }
+            for f in document.files
+            if f.upload_completed_at is not None
+        ],
+    }
+
+    payload = json.dumps(event, separators=(",", ":")).encode("utf-8")
+
+    future = publisher.publish(
+        _topic_path(_TOPIC_DOCUMENT_UPLOADED),
+        payload,
+        ordering_key=document.id,
+        event_type="DocumentUploaded",
+        schema_version=EVENT_SCHEMA_VERSION,
+    )
+    message_id = future.result(timeout=_PUBLISH_TIMEOUT_SECONDS)
+
+    _log.info(
+        "event_published topic=%s message_id=%s event_id=%s document_id=%s",
+        _TOPIC_DOCUMENT_UPLOADED, message_id, event["event_id"], document.id,
+    )
+    return message_id

--- a/Backend/shared/repositories/documents.py
+++ b/Backend/shared/repositories/documents.py
@@ -1,107 +1,391 @@
 """
 Repository for the `documents` Firestore collection.
 
-Callers go through these functions instead of touching Firestore directly. This is
-the seam where we can later add caching, switch databases, or substitute a fake
-implementation in tests.
+The collection stores logical Documents; each Document carries its files as an
+embedded array (well within Firestore's 1 MB per-document limit at the file
+counts this API allows).
+
+All read paths take a `uid` and refuse to return another user's data — the
+authorisation boundary lives here so endpoints can't accidentally bypass it.
 """
 
+import base64
+import json
 import logging
 import uuid
 from datetime import datetime, timezone
+from typing import Iterable
 
-from firebase_admin import firestore
+from firebase_admin import firestore as firebase_firestore
+from google.cloud.firestore_v1 import (
+    FieldFilter,
+    Query,
+    Transaction,
+    transactional,
+)
 
 from shared.firestore import get_firestore
-from shared.models.document import Document, DocumentStatus
+from shared.models.document import (
+    Document,
+    DocumentFile,
+    DocumentStatus,
+)
 
 _log = logging.getLogger(__name__)
 _COLLECTION = "documents"
 
 
-def _new_id() -> str:
+# ──────────────────────────────────────────────────────────────────────────────
+# ID generation & cursor encoding
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _new_document_id() -> str:
     return f"doc_{uuid.uuid4().hex}"
 
 
-def create_document(
+def _new_file_id() -> str:
+    return f"f_{uuid.uuid4().hex}"
+
+
+def _encode_cursor(created_at: datetime, document_id: str) -> str:
+    """Encode a pagination cursor as URL-safe base64 of `{c, i}`."""
+    payload = json.dumps(
+        {"c": created_at.isoformat(), "i": document_id},
+        separators=(",", ":"),
+    )
+    return base64.urlsafe_b64encode(payload.encode()).rstrip(b"=").decode()
+
+
+def decode_cursor(cursor: str) -> tuple[datetime, str]:
+    """Reverse of `_encode_cursor`. Raises ValueError on malformed input."""
+    try:
+        padding = "=" * (-len(cursor) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(cursor + padding).decode())
+        return datetime.fromisoformat(payload["c"]), payload["i"]
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("malformed cursor") from exc
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Firestore <-> Pydantic mapping
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _snapshot_to_document(snapshot) -> Document:
+    """Convert a Firestore document snapshot into a Document.
+
+    Returned timestamps come from Firestore as `DatetimeWithNanoseconds` (a
+    `datetime` subclass) so Pydantic accepts them without coercion.
+    """
+    data = snapshot.to_dict() or {}
+    return Document(**data)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Creates
+# ──────────────────────────────────────────────────────────────────────────────
+
+class FileCreationSpec:
+    """Input for one file at document creation time. Mirrors `DocumentFile`
+    minus server-assigned fields (`file_id`, `gcs_object_path`, timestamps)."""
+
+    __slots__ = ("file_name", "content_type", "size_bytes")
+
+    def __init__(self, *, file_name: str, content_type: str, size_bytes: int):
+        self.file_name = file_name
+        self.content_type = content_type
+        self.size_bytes = size_bytes
+
+
+def create_document_with_files(
     *,
     uid: str,
-    file_name: str,
-    content_type: str,
-    size_bytes: int,
     domain: str,
+    title: str | None,
+    file_specs: list[FileCreationSpec],
+    idempotency_key: str | None,
+    object_path_builder,
 ) -> Document:
-    """Persist a new document record in PENDING_UPLOAD state and return it.
+    """Persist a new Document plus its files in a single Firestore write.
 
-    The created_at/updated_at on the returned Document are best-effort client time.
-    The canonical values written to Firestore use SERVER_TIMESTAMP and may differ
-    from the returned object by up to a few hundred milliseconds.
+    The caller supplies an `object_path_builder` callable that, given a
+    `file_id` and extension, returns the GCS object path. This keeps the
+    repository ignorant of GCS layout details while letting the caller
+    construct paths under any prefix scheme it wants.
     """
     db = get_firestore()
-    doc_id = _new_id()
+    document_id = _new_document_id()
     now = datetime.now(timezone.utc)
+    total_bytes = sum(spec.size_bytes for spec in file_specs)
 
-    # SERVER_TIMESTAMP is atomic with the write and ordered by server clock.
-    # Client wall clocks drift; we don't trust them for ordering.
-    db.collection(_COLLECTION).document(doc_id).set(
-        {
-            "id": doc_id,
-            "uid": uid,
-            "file_name": file_name,
-            "content_type": content_type,
-            "size_bytes": size_bytes,
-            "domain": domain,
-            "status": DocumentStatus.PENDING_UPLOAD.value,
-            "gcs_uri": None,
-            "created_at": firestore.SERVER_TIMESTAMP,
-            "updated_at": firestore.SERVER_TIMESTAMP,
-            "error": None,
-        }
-    )
+    from shared.models.document import EXTENSION_BY_CONTENT_TYPE
+    files: list[dict] = []
+    for spec in file_specs:
+        file_id = _new_file_id()
+        extension = EXTENSION_BY_CONTENT_TYPE[spec.content_type]
+        object_path = object_path_builder(
+            document_id=document_id,
+            file_id=file_id,
+            extension=extension,
+        )
+        files.append(
+            {
+                "file_id": file_id,
+                "file_name": spec.file_name,
+                "content_type": spec.content_type,
+                "size_bytes": spec.size_bytes,
+                "gcs_object_path": object_path,
+                "upload_completed_at": None,
+            }
+        )
+
+    payload = {
+        "id": document_id,
+        "uid": uid,
+        "domain": domain,
+        "title": title,
+        "status": DocumentStatus.PENDING_UPLOAD.value,
+        "files": files,
+        "file_count": len(files),
+        "total_bytes": total_bytes,
+        "idempotency_key": idempotency_key,
+        "created_at": firebase_firestore.SERVER_TIMESTAMP,
+        "updated_at": firebase_firestore.SERVER_TIMESTAMP,
+        "finalized_at": None,
+        "deleted_at": None,
+        "error": None,
+    }
+
+    db.collection(_COLLECTION).document(document_id).set(payload)
 
     _log.info(
-        "document_created id=%s uid=%s domain=%s size_bytes=%d",
-        doc_id, uid, domain, size_bytes,
+        "document_created document_id=%s uid=%s domain=%s file_count=%d total_bytes=%d",
+        document_id, uid, domain, len(files), total_bytes,
     )
 
+    # The returned object uses client-side timestamps as a best-effort
+    # approximation; the canonical values written via SERVER_TIMESTAMP may
+    # differ by up to a few hundred milliseconds.
     return Document(
-        id=doc_id,
+        id=document_id,
         uid=uid,
-        file_name=file_name,
-        content_type=content_type,
-        size_bytes=size_bytes,
         domain=domain,
+        title=title,
         status=DocumentStatus.PENDING_UPLOAD,
-        gcs_uri=None,
+        files=[DocumentFile(**f) for f in files],
+        file_count=len(files),
+        total_bytes=total_bytes,
+        idempotency_key=idempotency_key,
         created_at=now,
         updated_at=now,
+        finalized_at=None,
+        deleted_at=None,
         error=None,
     )
 
 
-def get_document(doc_id: str) -> Document | None:
-    """Fetch a document by id. Returns None if the id does not exist."""
+# ──────────────────────────────────────────────────────────────────────────────
+# Reads
+# ──────────────────────────────────────────────────────────────────────────────
+
+def find_document_for_user(document_id: str, uid: str) -> Document | None:
+    """Read a document if and only if it belongs to `uid` and is not deleted."""
     db = get_firestore()
-    snapshot = db.collection(_COLLECTION).document(doc_id).get()
+    snapshot = db.collection(_COLLECTION).document(document_id).get()
     if not snapshot.exists:
         return None
-    return Document(**snapshot.to_dict())
+    document = _snapshot_to_document(snapshot)
+    if document.uid != uid or document.deleted_at is not None:
+        return None
+    return document
 
 
-def update_status(
-    doc_id: str,
-    status: DocumentStatus,
-    *,
-    error: str | None = None,
-) -> None:
-    """Transition a document to a new status. Optionally record an error message."""
+def find_document_by_idempotency_key(uid: str, idempotency_key: str) -> Document | None:
+    """Look up a document by `(uid, idempotency_key)`. Returns None if absent.
+
+    Backed by the `(uid, idempotency_key)` composite index declared in
+    `firestore.indexes.json`.
+    """
     db = get_firestore()
-    patch: dict = {
-        "status": status.value,
-        "updated_at": firestore.SERVER_TIMESTAMP,
-    }
-    if error is not None:
-        patch["error"] = error
-    db.collection(_COLLECTION).document(doc_id).update(patch)
+    query = (
+        db.collection(_COLLECTION)
+        .where(filter=FieldFilter("uid", "==", uid))
+        .where(filter=FieldFilter("idempotency_key", "==", idempotency_key))
+        .limit(1)
+    )
+    for snapshot in query.stream():
+        return _snapshot_to_document(snapshot)
+    return None
 
-    _log.info("document_status_updated id=%s status=%s", doc_id, status.value)
+
+def list_documents_for_user(
+    uid: str,
+    *,
+    domain: str | None = None,
+    status: DocumentStatus | None = None,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> tuple[list[Document], str | None]:
+    """Paginated list of a user's documents, newest first.
+
+    Returns `(documents, next_cursor)`. `next_cursor` is None when no further
+    pages remain. Excludes soft-deleted documents.
+    """
+    db = get_firestore()
+    query = (
+        db.collection(_COLLECTION)
+        .where(filter=FieldFilter("uid", "==", uid))
+        .where(filter=FieldFilter("deleted_at", "==", None))
+        .order_by("created_at", direction=Query.DESCENDING)
+        .order_by("id", direction=Query.DESCENDING)
+    )
+
+    if domain is not None:
+        query = query.where(filter=FieldFilter("domain", "==", domain))
+    if status is not None:
+        query = query.where(filter=FieldFilter("status", "==", status.value))
+
+    # Fetch one extra to detect "is there a next page".
+    query = query.limit(limit + 1)
+
+    if cursor:
+        cursor_dt, cursor_id = decode_cursor(cursor)
+        query = query.start_after([cursor_dt, cursor_id])
+
+    snapshots = list(query.stream())
+    has_next = len(snapshots) > limit
+    if has_next:
+        snapshots = snapshots[:limit]
+
+    documents = [_snapshot_to_document(s) for s in snapshots]
+
+    next_cursor: str | None = None
+    if has_next and documents:
+        last = documents[-1]
+        next_cursor = _encode_cursor(last.created_at, last.id)
+
+    return documents, next_cursor
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# State transitions
+# ──────────────────────────────────────────────────────────────────────────────
+
+class DocumentStateError(Exception):
+    """Raised when a transition is attempted from an incompatible state."""
+
+    def __init__(self, current_status: DocumentStatus):
+        super().__init__(f"document is in state {current_status.value}")
+        self.current_status = current_status
+
+
+def mark_uploaded(
+    document_id: str,
+    uid: str,
+    uploaded_file_ids: Iterable[str],
+) -> Document:
+    """Atomically transition `pending_upload` → `uploaded`.
+
+    Uses a Firestore transaction so concurrent finalize attempts cannot both
+    succeed. Refuses if the document is missing, owned by another user, soft
+    deleted, or in any state other than `pending_upload`.
+
+    `uploaded_file_ids` is the set of files verified to exist in GCS — these
+    get an `upload_completed_at` stamp. The document's `file_count` is updated
+    to match (partial uploads are tolerated; the worker handles them).
+    """
+    db = get_firestore()
+    doc_ref = db.collection(_COLLECTION).document(document_id)
+    uploaded_ids = set(uploaded_file_ids)
+    now = datetime.now(timezone.utc)
+
+    @transactional
+    def _txn(transaction: Transaction) -> Document:
+        snapshot = doc_ref.get(transaction=transaction)
+        if not snapshot.exists:
+            raise LookupError("document not found")
+
+        data = snapshot.to_dict() or {}
+        if data.get("uid") != uid or data.get("deleted_at") is not None:
+            raise LookupError("document not found")
+
+        current_status = DocumentStatus(data["status"])
+        if current_status is not DocumentStatus.PENDING_UPLOAD:
+            raise DocumentStateError(current_status)
+
+        files: list[dict] = list(data.get("files", []))
+        updated_files: list[dict] = []
+        for file_dict in files:
+            if file_dict["file_id"] in uploaded_ids:
+                file_dict = {**file_dict, "upload_completed_at": now}
+            updated_files.append(file_dict)
+
+        transaction.update(
+            doc_ref,
+            {
+                "status": DocumentStatus.UPLOADED.value,
+                "files": updated_files,
+                "file_count": len(uploaded_ids),
+                "finalized_at": firebase_firestore.SERVER_TIMESTAMP,
+                "updated_at": firebase_firestore.SERVER_TIMESTAMP,
+            },
+        )
+
+        return Document(
+            **{
+                **data,
+                "status": DocumentStatus.UPLOADED.value,
+                "files": updated_files,
+                "file_count": len(uploaded_ids),
+                "finalized_at": now,
+                "updated_at": now,
+            }
+        )
+
+    document = _txn(db.transaction())
+
+    _log.info(
+        "document_finalized document_id=%s uid=%s uploaded_count=%d declared_count=%d",
+        document_id, uid, len(uploaded_ids), document.file_count,
+    )
+    return document
+
+
+def soft_delete(document_id: str, uid: str) -> None:
+    """Mark a document as deleted. Refuses if status is `processing`.
+
+    Files in GCS are not touched here — a background reconciliation job
+    hard-deletes them after the retention window. This keeps the delete
+    user-facing latency low and gives operators a window to undo.
+    """
+    db = get_firestore()
+    doc_ref = db.collection(_COLLECTION).document(document_id)
+
+    @transactional
+    def _txn(transaction: Transaction) -> None:
+        snapshot = doc_ref.get(transaction=transaction)
+        if not snapshot.exists:
+            raise LookupError("document not found")
+
+        data = snapshot.to_dict() or {}
+        if data.get("uid") != uid or data.get("deleted_at") is not None:
+            raise LookupError("document not found")
+
+        current_status = DocumentStatus(data["status"])
+        if current_status is DocumentStatus.PROCESSING:
+            raise DocumentStateError(current_status)
+
+        transaction.update(
+            doc_ref,
+            {
+                "deleted_at": firebase_firestore.SERVER_TIMESTAMP,
+                "updated_at": firebase_firestore.SERVER_TIMESTAMP,
+            },
+        )
+
+    _txn(db.transaction())
+    _log.info("document_soft_deleted document_id=%s uid=%s", document_id, uid)
+
+
+def pending_files(document: Document) -> list[DocumentFile]:
+    """Return files in a document that have not yet completed upload."""
+    return [f for f in document.files if f.upload_completed_at is None]

--- a/Backend/workers/main.py
+++ b/Backend/workers/main.py
@@ -1,13 +1,10 @@
 """
 Ailixir Worker Service.
 
-Internal Pub/Sub push receiver for background AI pipeline tasks (OCR, LLM
-extraction, embedding). This service is NOT exposed to the public internet —
-it is only reachable by Google Cloud Pub/Sub push subscriptions.
-
-No authentication middleware is applied here. Cloud Run ingress should be
-restricted to internal traffic; the Pub/Sub service account is the only
-caller.
+Internal Pub/Sub push receiver for background AI pipeline tasks. The service
+is reachable only from inside GCP — Cloud Run ingress is set to internal +
+load-balancer, and Pub/Sub authenticates each push with an OIDC token signed
+by a dedicated service account.
 
 Run from the `Backend/` directory:
     uvicorn workers.main:app --reload --port 8080
@@ -16,17 +13,39 @@ Run from the `Backend/` directory:
 import base64
 import json
 import logging
+import os
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Request, status
-from fastapi.openapi.utils import get_openapi
-from pydantic import BaseModel
 from dotenv import load_dotenv
+from fastapi import FastAPI, Header, HTTPException, status
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
+from pydantic import BaseModel
 
 load_dotenv()
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
 logger = logging.getLogger(__name__)
+
+
+# Audience the push subscription was configured to set in OIDC tokens. The
+# Cloud Run URL of this worker is the canonical value; in local dev we relax
+# verification (see `_verify_oidc_token`).
+_OIDC_AUDIENCE = os.getenv("PUBSUB_PUSH_AUDIENCE", "")
+
+# Email of the service account terraform created for Pub/Sub-to-worker pushes.
+# Verifying this prevents impersonation even if someone else acquires a valid
+# Google OIDC token for the worker's audience.
+_OIDC_TRUSTED_EMAIL = os.getenv("PUBSUB_PUSH_SERVICE_ACCOUNT", "")
+
+# Local dev / emulator escape hatch. Set to "1" to skip OIDC verification.
+# Never set this in production — terraform must inject `_OIDC_AUDIENCE` and
+# `_OIDC_TRUSTED_EMAIL` so the prod path is taken.
+_SKIP_OIDC_VERIFICATION = os.getenv("PUBSUB_SKIP_OIDC_VERIFICATION", "").lower() in {"1", "true"}
+
 
 app = FastAPI(
     title="Ailixir Worker Service",
@@ -34,10 +53,7 @@ app = FastAPI(
     description="""
 ## Internal Pub/Sub push receiver for AI pipeline workers.
 
-This service is called exclusively by Google Cloud Pub/Sub — it is not
-a public API. No authentication is applied at the HTTP layer; access
-control is enforced at the infrastructure level (Cloud Run ingress policy
-and Pub/Sub service account permissions).
+Authenticated by Pub/Sub-signed OIDC tokens. Not a public API.
 """,
     contact={
         "name": "Hasnat Ahmed",
@@ -49,16 +65,14 @@ and Pub/Sub service account permissions).
 )
 
 
-# ---------------------------------------------------------------------------
-# Pub/Sub message models
-# ---------------------------------------------------------------------------
+# ──────────────────────────────────────────────────────────────────────────────
+# Pub/Sub envelope models
+# ──────────────────────────────────────────────────────────────────────────────
 
 class PubSubMessage(BaseModel):
     """The inner message envelope sent by Cloud Pub/Sub."""
 
-    data: str
-    """Base64-encoded payload published by the producer."""
-
+    data: str  # base64-encoded
     messageId: str
     message_id: str | None = None
     publishTime: str
@@ -68,22 +82,87 @@ class PubSubMessage(BaseModel):
 
 
 class PubSubEnvelope(BaseModel):
-    """Top-level JSON body that Pub/Sub delivers to the push endpoint."""
+    """Top-level JSON body Pub/Sub delivers to the push endpoint."""
 
     message: PubSubMessage
     subscription: str
     deliveryAttempt: int | None = None
 
 
-# ---------------------------------------------------------------------------
+# ──────────────────────────────────────────────────────────────────────────────
+# OIDC verification
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _verify_oidc_token(authorization_header: str | None) -> None:
+    """Validate the OIDC token Pub/Sub attached to the push request.
+
+    Raises 401 if the token is missing, malformed, expired, signed by an
+    untrusted issuer, has the wrong audience, or was minted by an unexpected
+    service account.
+
+    Skipped entirely when `PUBSUB_SKIP_OIDC_VERIFICATION=1` (local emulator).
+    """
+    if _SKIP_OIDC_VERIFICATION:
+        return
+
+    if not authorization_header or not authorization_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing bearer token.")
+
+    token = authorization_header.split(" ", 1)[1].strip()
+
+    try:
+        claims = id_token.verify_oauth2_token(
+            token,
+            google_requests.Request(),
+            audience=_OIDC_AUDIENCE or None,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"OIDC verification failed: {exc}",
+        ) from exc
+
+    if _OIDC_TRUSTED_EMAIL and claims.get("email") != _OIDC_TRUSTED_EMAIL:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="OIDC token from unexpected service account.",
+        )
+    if not claims.get("email_verified", False):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="OIDC token email not verified.",
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Event dispatch
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _handle_document_uploaded(payload: dict[str, Any]) -> None:
+    """Stub for the ingestion pipeline. Real OCR / extraction lands in a
+    later ticket — for now we log the event so the round-trip is visible."""
+    logger.info(
+        "document_uploaded_event document_id=%s uid=%s domain=%s file_count=%s",
+        payload.get("document_id"),
+        payload.get("uid"),
+        payload.get("domain"),
+        payload.get("file_count"),
+    )
+
+
+_EVENT_HANDLERS = {
+    "DocumentUploaded": _handle_document_uploaded,
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Routes
-# ---------------------------------------------------------------------------
+# ──────────────────────────────────────────────────────────────────────────────
 
 @app.get(
     "/health",
     tags=["System"],
     summary="Health check",
-    response_description="Service is running",
 )
 def health() -> dict:
     return {"status": "ok"}
@@ -94,41 +173,45 @@ def health() -> dict:
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["Pub/Sub"],
     summary="Pub/Sub push endpoint",
-    response_description="Message acknowledged (empty body)",
-    responses={
-        204: {"description": "Message received and acknowledged"},
-        422: {"description": "Malformed Pub/Sub envelope"},
-    },
 )
-async def pubsub_push(envelope: PubSubEnvelope) -> None:
-    """Receive a Pub/Sub push message and dispatch it to the appropriate handler.
+async def pubsub_push(
+    envelope: PubSubEnvelope,
+    authorization: str | None = Header(default=None),
+) -> None:
+    """Receive a Pub/Sub push message, dispatch to the correct handler.
 
-    Pub/Sub retries delivery until it receives an HTTP 2xx response. Returning
-    204 (No Content) acknowledges the message. Raising an exception causes a
-    non-2xx response which tells Pub/Sub to redeliver.
-
-    The `data` field is base64-encoded. The decoded payload is expected to be
-    a JSON object whose `event_type` field routes the message to the correct
-    AI pipeline stage.
+    Returning 204 acks the message. Raising tells Pub/Sub to redeliver per the
+    subscription's retry policy; persistent failures land in the DLQ.
     """
-    raw = envelope.message.data
+    _verify_oidc_token(authorization)
 
+    raw = envelope.message.data
     try:
         payload: Any = json.loads(base64.b64decode(raw).decode("utf-8"))
     except Exception as exc:
         logger.error("Failed to decode Pub/Sub message data: %s", exc)
+        # 422 lets Pub/Sub mark the message as a permanent failure — DLQ
+        # routing prevents infinite redelivery of malformed bodies.
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Message data is not valid base64-encoded JSON.",
         ) from exc
 
+    event_type = payload.get("event_type") if isinstance(payload, dict) else None
     logger.info(
-        "Received Pub/Sub message | subscription=%s messageId=%s deliveryAttempt=%s payload=%s",
+        "pubsub_received subscription=%s message_id=%s event_type=%s delivery_attempt=%s",
         envelope.subscription,
         envelope.message.messageId,
+        event_type,
         envelope.deliveryAttempt,
-        payload,
     )
 
-    # TODO(routing): inspect payload["event_type"] and dispatch to the
-    # appropriate AI pipeline handler (ingestion, extraction, embedding, …).
+    handler = _EVENT_HANDLERS.get(event_type) if event_type else None
+    if handler is None:
+        # Unknown event type — ack so Pub/Sub doesn't loop. Worker version
+        # may simply not know about this event yet; logging is enough.
+        logger.warning("unknown_event_type event_type=%s message_id=%s",
+                       event_type, envelope.message.messageId)
+        return
+
+    handler(payload)

--- a/Backend/workers/requirements.txt
+++ b/Backend/workers/requirements.txt
@@ -3,5 +3,5 @@ uvicorn==0.46.0
 python-dotenv==1.0.1
 pydantic==2.13.3
 firebase-admin==7.4.0
-google-cloud-storage==2.18.2
+google-cloud-storage==3.10.1
 google-auth==2.50.0

--- a/Backend/workers/requirements.txt
+++ b/Backend/workers/requirements.txt
@@ -1,3 +1,7 @@
 fastapi==0.136.1
 uvicorn==0.46.0
 python-dotenv==1.0.1
+pydantic==2.13.3
+firebase-admin==7.4.0
+google-cloud-storage==2.18.2
+google-auth==2.50.0

--- a/Backend/workers/terraform/main.tf
+++ b/Backend/workers/terraform/main.tf
@@ -3,12 +3,52 @@ provider "google" {
   region  = var.region
 }
 
+locals {
+  worker_service_account_id   = "ailixir-worker"
+  pubsub_pusher_account_id    = "ailixir-pubsub-pusher"
+  topic_document_uploaded     = "document-uploaded"
+  topic_document_uploaded_dlq = "document-uploaded-dlq"
+  subscription_name           = "document-uploaded-ingestion"
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Service account the worker Cloud Run service runs as.
+# Needs Firestore access (to update document status) and GCS read access (to
+# read uploaded files for OCR). Permissions added incrementally as the worker
+# grows beyond a stub.
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "google_service_account" "worker" {
+  account_id   = local.worker_service_account_id
+  display_name = "Ailixir worker service account"
+  description  = "Runs the worker (Pub/Sub push receiver) on Cloud Run."
+}
+
+resource "google_project_iam_member" "worker_firestore_user" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.worker.email}"
+}
+
+resource "google_project_iam_member" "worker_storage_object_viewer" {
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.worker.email}"
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Cloud Run worker service.
+# ──────────────────────────────────────────────────────────────────────────────
 
 resource "google_cloud_run_v2_service" "worker" {
   name     = "ailixir-worker"
   location = var.region
 
   template {
+    service_account = google_service_account.worker.email
+
     containers {
       image = "gcr.io/${var.project_id}/ailixir-worker:${var.image_tag}"
 
@@ -20,10 +60,117 @@ resource "google_cloud_run_v2_service" "worker" {
         name  = "GCP_PROJECT_ID"
         value = var.project_id
       }
+      env {
+        name  = "FIREBASE_PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        # Empty audience disables the OIDC `aud` check; the worker still
+        # verifies the token's `email` claim against PUBSUB_PUSH_SERVICE_ACCOUNT,
+        # which is the actual identity gate. We leave audience empty because
+        # passing the Cloud Run URL here would require a terraform two-pass
+        # (the URL is a self-reference that doesn't exist until after create).
+        name  = "PUBSUB_PUSH_AUDIENCE"
+        value = ""
+      }
+      env {
+        name  = "PUBSUB_PUSH_SERVICE_ACCOUNT"
+        value = google_service_account.pubsub_pusher.email
+      }
+      env {
+        name  = "PUBSUB_SKIP_OIDC_VERIFICATION"
+        value = "0"
+      }
+      env {
+        name  = "FIREBASE_KEY_RELATIVE_PATH"
+        value = ""
+      }
     }
   }
 }
 
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Service account Pub/Sub uses to sign OIDC tokens when pushing to the worker.
+# A dedicated SA (separate from the worker's own SA) lets the worker positively
+# identify push requests via the `email` claim.
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "google_service_account" "pubsub_pusher" {
+  account_id   = local.pubsub_pusher_account_id
+  display_name = "Pub/Sub → Worker push identity"
+  description  = "Mints OIDC tokens that Pub/Sub attaches to push requests."
+}
+
+# Allow the push SA to invoke the worker Cloud Run service.
+resource "google_cloud_run_v2_service_iam_member" "pusher_invoker" {
+  name     = google_cloud_run_v2_service.worker.name
+  location = google_cloud_run_v2_service.worker.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.pubsub_pusher.email}"
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Subscription that delivers DocumentUploaded events to the worker.
+#
+# The topic itself is declared in api/terraform/. Referencing by name keeps the
+# two states independent — order of apply doesn't matter as long as both have
+# been applied at least once.
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "google_pubsub_subscription" "ingestion" {
+  name  = local.subscription_name
+  topic = "projects/${var.project_id}/topics/${local.topic_document_uploaded}"
+
+  ack_deadline_seconds       = 600
+  message_retention_duration = "604800s"  # 7 days
+  retain_acked_messages      = false
+  enable_message_ordering    = true
+
+  push_config {
+    push_endpoint = "${google_cloud_run_v2_service.worker.uri}/pubsub/push"
+
+    oidc_token {
+      service_account_email = google_service_account.pubsub_pusher.email
+      # `audience` defaults to the push_endpoint URL; explicit for clarity.
+      audience = google_cloud_run_v2_service.worker.uri
+    }
+  }
+
+  expiration_policy {
+    # Never auto-expire; the subscription lives as long as the topic does.
+    ttl = ""
+  }
+
+  retry_policy {
+    minimum_backoff = "10s"
+    maximum_backoff = "600s"
+  }
+
+  dead_letter_policy {
+    dead_letter_topic     = "projects/${var.project_id}/topics/${local.topic_document_uploaded_dlq}"
+    max_delivery_attempts = 5
+  }
+
+  depends_on = [
+    google_cloud_run_v2_service_iam_member.pusher_invoker,
+  ]
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Outputs.
+# ──────────────────────────────────────────────────────────────────────────────
+
 output "worker_url" {
   value = google_cloud_run_v2_service.worker.uri
+}
+
+output "worker_service_account_email" {
+  value = google_service_account.worker.email
+}
+
+output "pubsub_pusher_service_account_email" {
+  value = google_service_account.pubsub_pusher.email
 }

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "indexes": "Backend/firestore.indexes.json"
+  }
+}


### PR DESCRIPTION
Replaces the old single-file /documents/upload that didn't actually persist files. New flow: client POSTs metadata, gets v4 signed PUT URLs, uploads directly to GCS, then calls finalize to verify and transition status to 'uploaded'. Worker is notified via a DocumentUploaded Pub/Sub event with ordering key = document_id.

API surface:
- POST   /documents                              (idempotent via Idempotency-Key header)
- POST   /documents/{id}/finalize                (verifies GCS, publishes event)
- POST   /documents/{id}/upload-urls/refresh     (re-issues signed URLs for pending files)
- GET    /documents                              (paginated, filterable by domain + status)
- GET    /documents/{id}                         (returns signed download URLs)
- DELETE /documents/{id}                         (soft delete; refuses if processing)

Model changes:
- Document now carries a files array + title + finalized_at + deleted_at
  + idempotency_key. extra='ignore' so older records deserialize cleanly.
- DocumentFile is embedded (not a subcollection — well within 1 MB limit).

Cross-cutting:
- Request-ID middleware propagates X-Request-ID into every log line and response header so support can trace user complaints to exact logs.
- Structured error envelope (code/message/request_id) replaces FastAPI's bare detail string. Stable ErrorCode enum for client switch statements.
- Pydantic validation up front: domain allow-list, content-type allow-list, size caps, file_name sanitisation (path traversal, control chars, NFKC).

Infrastructure (terraform):
- GCS bucket with versioning, lifecycle, CORS, uniform IAM.
- Pub/Sub topic + DLQ (api/terraform/).
- Push subscription with OIDC + run.invoker (workers/terraform/).
- Dedicated SAs for API and worker, plus a separate SA for Pub/Sub-to- worker push tokens. API SA has serviceAccountTokenCreator on itself so v4 signed URLs work on Cloud Run without a private key file.

Worker hardening:
- OIDC token verification on /pubsub/push (skippable for local emulator).
- Event dispatch by event_type; ack-on-unknown to avoid retry loops.