### PR TITLE
feat(chat-agent): add streaming endpoint, multi-turn memory, guardrai…

### DIFF
--- a/ai-playground/chat-app/.env.example
+++ b/ai-playground/chat-app/.env.example
@@ -1,3 +1,4 @@
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 GOOGLE_CLOUD_LOCATION=us-central1
 VERTEX_PROJECT_ID=your-VERTEX-project-id
+DB_URI=postgresql://postgres:yourpassword@localhost:5432/yourdatabasename

--- a/ai-playground/chat-app/graph/builder.py
+++ b/ai-playground/chat-app/graph/builder.py
@@ -1,70 +1,150 @@
+"""
+graph/builder.py
+----------------
+Assembles the LangGraph StateGraph and wires up the PostgreSQL checkpointer.
+
+Graph shape
+-----------
+
+    guardrail_node
+         │
+    ─────┼──── intent=="BLOCKED" ──▶ END
+         │
+    intent_node
+         │
+    ─────┼──── intent=="FOLLOWUP" ──▶ rewrite_node ──┐
+         │                                            │
+         └────────── NEW_QUESTION ────────────────────┤
+                                                      │
+                                                 retrieve_node
+                                                      │
+                                        ─────────────────────────
+                                        streaming==True  │  False
+                                              END        │  answer_node
+                                                         │
+                                                        END
+
+The streaming branch skips answer_node so main.py can call Gemini with
+stream=True and pipe tokens directly to the SSE client — no wasted non-
+streaming LLM call inside the graph.
+
+DB setup
+--------
+LangGraph's checkpointer.setup() creates the two required tables
+(checkpoints, writes) on first run if they don't already exist.
+init_db.py is therefore only needed for local dev environments that want
+to pre-create the schema before first startup.
+"""
+
+import os
+from pathlib import Path
+
+import psycopg
+from dotenv import load_dotenv
 from langgraph.graph import StateGraph, END
 from langgraph.checkpoint.postgres import PostgresSaver
-from psycopg import Connection
 
 from graph.state import AgentState
 from graph.nodes import (
-    detect_intent_node,
-    rewrite_question_node,
+    guardrail_node,
+    intent_node,
+    rewrite_node,
     retrieve_node,
     answer_node,
-    guardrail_node,
 )
 
-DB_URI = "postgresql://postgres:123@localhost:5432/ailixir"
+# ---------------------------------------------------------------------------
+# Load .env — lives in ai-playground/ which is:
+#   chat-app/graph/builder.py  →  ../../  →  ai-playground/
+# load_dotenv is a no-op if the vars are already in the environment,
+# so this is safe to call even in production.
+# ---------------------------------------------------------------------------
+
+_ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
+load_dotenv(_ENV_PATH)
+
+# ---------------------------------------------------------------------------
+# Database URI — always from environment, never hardcoded
+# ---------------------------------------------------------------------------
+
+DB_URI = os.getenv(
+    "DB_URI",
+    "postgresql://postgres:password@localhost:5432/ailixir",  # fallback for local dev
+)
 
 
-def route_after_guardrail(state: AgentState):
-    return "blocked" if state.get("intent") == "BLOCKED" else "allowed"
+# ---------------------------------------------------------------------------
+# Routing functions
+# ---------------------------------------------------------------------------
+
+def _route_after_guardrail(state: AgentState) -> str:
+    """Block immediately if guardrail fired; otherwise continue to intent."""
+    return END if state.get("intent") == "BLOCKED" else "intent_node"
 
 
-def route_after_intent(state: AgentState):
-    return "rewrite" if state["intent"] == "FOLLOWUP" else "retrieve"
+def _route_after_intent(state: AgentState) -> str:
+    """Follow-ups need rewriting; new questions go straight to retrieval."""
+    return "rewrite_node" if state.get("intent") == "FOLLOWUP" else "retrieve_node"
 
+
+def _route_after_retrieve(state: AgentState) -> str:
+    """
+    If the caller set streaming=True (the /chat/stream endpoint), skip the
+    answer node entirely — main.py will stream Gemini directly.
+    Otherwise, run the answer node for a complete synchronous response.
+    """
+    return END if state.get("streaming") else "answer_node"
+
+
+# ---------------------------------------------------------------------------
+# Graph factory
+# ---------------------------------------------------------------------------
 
 def build_graph():
+    """
+    Builds and compiles the LangGraph agent with a PostgreSQL checkpointer.
 
-    workflow = StateGraph(AgentState)
+    Call once on application startup (FastAPI lifespan).
+    """
+    builder = StateGraph(AgentState)
 
-    # --- Nodes ---
-    workflow.add_node("guardrail", guardrail_node)
-    workflow.add_node("intent", detect_intent_node)
-    workflow.add_node("rewrite", rewrite_question_node)
-    workflow.add_node("retrieve", retrieve_node)
-    workflow.add_node("answer", answer_node)
+    # Register nodes
+    builder.add_node("guardrail_node", guardrail_node)
+    builder.add_node("intent_node",    intent_node)
+    builder.add_node("rewrite_node",   rewrite_node)
+    builder.add_node("retrieve_node",  retrieve_node)
+    builder.add_node("answer_node",    answer_node)
 
-    # --- Entry point ---
-    workflow.set_entry_point("guardrail")
+    # Entry point
+    builder.set_entry_point("guardrail_node")
 
-    # --- Guardrail: allow → intent, block → END ---
-    workflow.add_conditional_edges(
-        "guardrail",
-        route_after_guardrail,
-        {
-            "allowed": "intent",
-            "blocked": END,
-        },
+    # Edges
+    builder.add_conditional_edges(
+        "guardrail_node",
+        _route_after_guardrail,
+        {"intent_node": "intent_node", END: END},
     )
 
-    # --- Intent: followup → rewrite, new → retrieve ---
-    workflow.add_conditional_edges(
-        "intent",
-        route_after_intent,
-        {
-            "rewrite": "rewrite",
-            "retrieve": "retrieve",
-        },
+    builder.add_conditional_edges(
+        "intent_node",
+        _route_after_intent,
+        {"rewrite_node": "rewrite_node", "retrieve_node": "retrieve_node"},
     )
 
-    workflow.add_edge("rewrite", "retrieve")
-    workflow.add_edge("retrieve", "answer")
-    workflow.add_edge("answer", END)
+    # rewrite always feeds into retrieve
+    builder.add_edge("rewrite_node", "retrieve_node")
 
-    # --- Postgres checkpointer ---
-    conn = Connection.connect(DB_URI)
-    conn.autocommit = True
+    builder.add_conditional_edges(
+        "retrieve_node",
+        _route_after_retrieve,
+        {"answer_node": "answer_node", END: END},
+    )
 
-    checkpointer = PostgresSaver(conn)
-    checkpointer.setup()
+    builder.add_edge("answer_node", END)
 
-    return workflow.compile(checkpointer=checkpointer)
+    # Checkpointer (session memory via PostgreSQL)
+    connection = psycopg.connect(DB_URI)
+    checkpointer = PostgresSaver(connection)
+    checkpointer.setup()   # creates tables if they don't exist — idempotent
+
+    return builder.compile(checkpointer=checkpointer)

--- a/ai-playground/chat-app/graph/nodes.py
+++ b/ai-playground/chat-app/graph/nodes.py
@@ -1,259 +1,507 @@
+"""
+graph/nodes.py
+--------------
+Every node in the LangGraph pipeline lives here.
+main.py imports constants and helpers — it does NOT duplicate any logic.
+
+Node execution order (wired in builder.py):
+  guardrail_node → intent_node → rewrite_node → retrieve_node → answer_node
+                                                                 ↑ skipped when
+                                                                   state.streaming=True
+
+KG integration note (issue #75)
+--------------------------------
+To swap in knowledge-graph retrieval, replace the body of `_retrieve_from_documents`
+with your KG client call, or add a second function `_retrieve_from_kg` and route
+between them inside `retrieve_node` based on a config flag or the query itself.
+No other file needs to change.
+"""
+
+from __future__ import annotations
+
 import json
 import os
+import re
+from pathlib import Path
+from typing import Literal
 
 import vertexai
-from vertexai.preview.generative_models import (
-    GenerativeModel,
-    GenerationConfig,
-)
-
-from langchain_core.messages import AIMessage
+from dotenv import load_dotenv
+from langchain_core.messages import HumanMessage, AIMessage
+from vertexai.preview.generative_models import GenerativeModel, GenerationConfig
 
 from graph.state import AgentState
 
-# --------------------------------------------------
-# Vertex AI setup
-# --------------------------------------------------
+# Load .env from ai-playground/ (two levels up from graph/nodes.py)
+# Safe to call multiple times — load_dotenv is idempotent.
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
-PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-LOCATION = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+# ---------------------------------------------------------------------------
+# Vertex AI — initialised once when the module is imported
+# ---------------------------------------------------------------------------
 
+# Env var names match BOTH the new .env keys AND Google Cloud conventions.
+# GOOGLE_CLOUD_PROJECT is the standard name used by all Google Cloud SDKs.
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("VERTEX_PROJECT")
+LOCATION   = os.getenv("GOOGLE_CLOUD_LOCATION") or os.getenv("VERTEX_LOCATION", "us-central1")
 GEMINI_MODEL = "gemini-2.5-flash"
-TEMPERATURE = 0.4
+TEMPERATURE  = 0.4
 
 vertexai.init(project=PROJECT_ID, location=LOCATION)
+_model = GenerativeModel(model_name=GEMINI_MODEL)
 
-model = GenerativeModel(model_name=GEMINI_MODEL)
+# ---------------------------------------------------------------------------
+# Guardrail constants  (imported by main.py — single source of truth)
+# ---------------------------------------------------------------------------
 
-# --------------------------------------------------
-# Load documents (mock retrieval source)
-# --------------------------------------------------
+REFUSAL_MESSAGE = (
+    "I can only answer questions about pharmaceutical documents. "
+    "Please ask something related to the uploaded materials."
+)
 
-DATA_FILE = "documents.json"
+# Patterns that indicate prompt-injection or jailbreak attempts
+BLOCKED_PATTERNS: list[str] = [
+    "ignore previous",
+    "ignore all previous",
+    "disregard",
+    "forget your instructions",
+    "pretend you are",
+    "act as",
+    "jailbreak",
+    "dan mode",
+    "developer mode",
+    "bypass",
+    "override instructions",
+    "new persona",
+    "you are now",
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _clean_messages(messages: list) -> list:
+    """
+    Remove malformed history entries so the intent classifier always sees
+    proper User → Assistant pairs.
+
+    Problem this solves
+    -------------------
+    If a previous version of answer_node saved only AIMessage (no preceding
+    HumanMessage), the history starts with "Assistant: ..." which confuses
+    the LLM classifier — it thinks there is no prior user context and returns
+    NEW_QUESTION even for obvious follow-ups.
+
+    Strategy: walk the list and only keep a HumanMessage if it is followed by
+    an AIMessage (i.e. a complete Q+A pair). Orphaned AIMessages at the start
+    are dropped entirely. This is safe to call on well-formed history too —
+    it is a no-op when all pairs are correct.
+    """
+    cleaned: list = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        if isinstance(msg, HumanMessage):
+            # Look ahead for the matching AIMessage
+            if i + 1 < len(messages) and isinstance(messages[i + 1], AIMessage):
+                cleaned.append(msg)
+                cleaned.append(messages[i + 1])
+                i += 2
+            else:
+                # Human with no following AI — skip (incomplete pair)
+                i += 1
+        elif isinstance(msg, AIMessage) and not cleaned:
+            # Leading orphan AI message (from old broken saves) — drop it
+            i += 1
+        else:
+            # Anything else mid-stream: keep and move on
+            cleaned.append(msg)
+            i += 1
+    return cleaned
 
 
-def load_documents():
-    with open(DATA_FILE, encoding="utf-8") as f:
-        return json.load(f)
+def get_history_text(messages: list) -> str:
+    """
+    Convert a list of LangChain messages into a plain-text conversation block
+    suitable for insertion into a prompt. Cleans malformed pairs first.
+    """
+    clean = _clean_messages(messages)
+    lines: list[str] = []
+    for msg in clean:
+        if isinstance(msg, HumanMessage):
+            lines.append(f"User: {msg.content}")
+        elif isinstance(msg, AIMessage):
+            lines.append(f"Assistant: {msg.content}")
+    return "\n".join(lines)
 
 
-DOCUMENTS = load_documents()
-
-# --------------------------------------------------
-# LLM helper
-# --------------------------------------------------
-
-
-def call_llm(prompt: str) -> str:
-    response = model.generate_content(
+def _call_llm(prompt: str, max_tokens: int = 1024) -> str:
+    """Single wrapper for all non-streaming Gemini calls in this file."""
+    response = _model.generate_content(
         prompt,
         generation_config=GenerationConfig(
             temperature=TEMPERATURE,
-            max_output_tokens=1024,
+            max_output_tokens=max_tokens,
         ),
     )
     return response.text.strip()
 
 
-# --------------------------------------------------
-# Retrieval (simple keyword baseline)
-# --------------------------------------------------
+# ---------------------------------------------------------------------------
+# Document retrieval (replace this section for KG integration — issue #75)
+# ---------------------------------------------------------------------------
+
+_DATA_FILE = Path(__file__).resolve().parent.parent / "documents.json"
+_documents: list[dict] | None = None   # lazy-loaded once
 
 
-def retrieve_context(query: str, top_k: int = 3) -> str:
+def _load_documents() -> list[dict]:
+    global _documents
+    if _documents is None:
+        with open(_DATA_FILE, encoding="utf-8") as f:
+            _documents = json.load(f)
+    return _documents
+
+
+def retrieve_context(query: str, top_k: int = 3) -> tuple[str, str]:
+    """
+    Keyword search over documents.json.
+
+    Returns
+    -------
+    (context_text, source_label)
+        context_text  — concatenated document passages for the LLM prompt
+        source_label  — "documents.json"  (will be "knowledge_graph" after #75)
+
+    KG swap point
+    -------------
+    Replace this function's body with your KG client call.
+    The return signature (context_text, source_label) must stay the same
+    so retrieve_node and the streaming path in main.py both work unchanged.
+    """
+    documents = _load_documents()
     query_words = set(query.lower().split())
-    scored = []
+    scored: list[tuple[int, dict]] = []
 
-    for doc in DOCUMENTS:
-        hits = sum(1 for w in query_words if w in doc["content"].lower())
+    for doc in documents:
+        hits = sum(1 for word in query_words if word in doc["content"].lower())
         if hits > 0:
             scored.append((hits, doc))
 
     scored.sort(key=lambda x: x[0], reverse=True)
-    top_docs = [d for _, d in scored[:top_k]] or DOCUMENTS[:top_k]
+    top_docs = [doc for _, doc in scored[:top_k]] or documents[:top_k]
 
-    return "\n\n---\n\n".join(f"[{d['title']}]\n{d['content']}" for d in top_docs)
-
-
-# --------------------------------------------------
-# Helper: extract message history as text
-# --------------------------------------------------
+    context_text = "\n\n---\n\n".join(
+        f"[{doc['title']}]\n{doc['content']}" for doc in top_docs
+    )
+    return context_text, "documents.json"
 
 
-def get_history_text(messages):
-    return "\n".join([f"{m.type}: {m.content}" for m in messages[-6:]])
+# ---------------------------------------------------------------------------
+# Node 1 — Guardrail
+# ---------------------------------------------------------------------------
 
+def guardrail_node(state: AgentState) -> dict:
+    """
+    Checks the question for:
+      1. Prompt-injection patterns (BLOCKED_PATTERNS list)
+      2. Off-topic intent — uses the LLM for robust classification instead of
+         a brittle keyword allowlist
 
-# ==================================================
-# NODE 0: Guardrail
-# ==================================================
+    Sets intent="BLOCKED" and fills answer with REFUSAL_MESSAGE if blocked.
+    The graph routes to END immediately in that case (see builder.py).
 
-BLOCKED_PATTERNS = [
-    "ignore previous",
-    "ignore all instructions",
-    "pretend you",
-    "you are now",
-    "jailbreak",
-    "system prompt",
-    "disregard your instructions",
-    "act as if",
-    "forget your rules",
-]
+    NOTE: this is the ONE place guardrail logic lives.
+    main.py must NOT duplicate this check.
+    """
+    question = state["question"]
+    q_lower  = question.lower()
 
-REFUSAL_MESSAGE = (
-    "I can only answer questions about the uploaded pharmaceutical documents. "
-    "Please ask a relevant question."
-)
-
-
-def guardrail_node(state: AgentState):
-    q = state["question"].lower()
-
-    # Block prompt injection / jailbreak attempts
-    if any(pattern in q for pattern in BLOCKED_PATTERNS):
+    # Fast path: injection pattern match (no LLM call needed)
+    if any(pattern in q_lower for pattern in BLOCKED_PATTERNS):
         return {
-            "answer": REFUSAL_MESSAGE,
             "intent": "BLOCKED",
-            "messages": [AIMessage(content=REFUSAL_MESSAGE)],
+            "answer": REFUSAL_MESSAGE,
         }
 
-    # Block obviously off-topic queries (no pharma/medical keywords at all)
-    # This is a lightweight heuristic — replace with a classifier for production
-    pharma_keywords = [
-        "drug",
-        "medicine",
-        "patient",
-        "dose",
-        "side effect",
-        "interaction",
-        "contraindication",
-        "trial",
-        "clinical",
-        "treatment",
-        "diabetes",
-        "warfarin",
-        "metformin",
-        "aspirin",
-        "bleeding",
-        "adverse",
-        "hba1c",
-        "summarize",
-        "summary",
-        "explain",
-        "what",
-        "how",
-        "why",
-        "when",
-        "document",
-        "report",
-        "tell",
-        "describe",
+    # LLM-based relevance check — much more robust than a keyword allowlist
+    # Classifies as RELEVANT or OFF_TOPIC; avoids false-blocking general
+    # questions like "summarize the document" or "my brother broke his leg".
+    classification_prompt = f"""You are a content classifier for a pharmaceutical document assistant.
+
+Decide if the following question is relevant to pharmaceutical documents, medicines,
+clinical trials, drug interactions, patient data, or document analysis.
+
+Reply with exactly one word: RELEVANT or OFF_TOPIC
+
+Question: {question}"""
+
+    try:
+        verdict = _call_llm(classification_prompt, max_tokens=10).upper().strip()
+        # Be lenient: only block if explicitly OFF_TOPIC
+        if "OFF_TOPIC" in verdict:
+            return {
+                "intent": "BLOCKED",
+                "answer": REFUSAL_MESSAGE,
+            }
+    except Exception:
+        # If the LLM call fails, allow the question through rather than
+        # silently blocking legitimate users
+        pass
+
+    return {}   # no changes to state — proceed to intent_node
+
+
+# ---------------------------------------------------------------------------
+# Node 2 — Intent detection
+# ---------------------------------------------------------------------------
+
+def intent_node(state: AgentState) -> dict:
+    """
+    Classifies the question as NEW_QUESTION or FOLLOWUP.
+    FOLLOWUP triggers the rewrite node; NEW_QUESTION skips it.
+
+    LangGraph merges the persisted messages from the checkpoint into the state
+    BEFORE the graph runs, so state["messages"] already contains the full
+    conversation history from previous turns when this node executes.
+    We exclude the last two entries (current turn's Human+AI) if they were
+    accidentally pre-populated, but in practice the messages list contains
+    only prior turns at this point.
+    """
+    messages = state.get("messages", [])
+
+    # Filter to only prior-turn messages — exclude any that match the
+    # current question (which hasn't been answered yet so won't be there,
+    # but guard defensively)
+    prior_messages = [
+        m for m in messages
+        if not (isinstance(m, HumanMessage) and m.content == state["question"])
     ]
-    if not any(kw in q for kw in pharma_keywords):
-        return {
-            "answer": REFUSAL_MESSAGE,
-            "intent": "BLOCKED",
-            "messages": [AIMessage(content=REFUSAL_MESSAGE)],
-        }
 
-    # Passed — continue to intent detection
-    return {}
+    history_text = get_history_text(prior_messages)
 
+    # Log so you can see what the node actually receives
+    print(f"[intent_node] messages in state: {len(messages)}, prior: {len(prior_messages)}")
+    print(f"[intent_node] history_text: {repr(history_text[:200]) if history_text else '(empty)'}")
 
-# ==================================================
-# NODE 1: Intent Detection
-# ==================================================
+    # ── Heuristic first — runs regardless of history quality ─────────────────
+    # If the question contains explicit follow-up language, classify it as
+    # FOLLOWUP immediately. This is robust even when stored history is malformed
+    # (all AIMessage, no UserMessage) or Postgres has been corrupted.
+    # Heuristic: only fire on UNAMBIGUOUS follow-up markers.
+    # Do NOT include: "in it", "described in", "mentioned in", "also", "what else"
+    # — these appear in new questions too ("What is described in the first document?")
+    # Only markers that make ZERO sense in a standalone new question are kept here.
+    FOLLOWUP_SIGNALS = [
+        "follow up", "followup", "follow-up",
+        "another followup", "another follow-up",
+        "what about that", "what about this",
+        "more about it", "more about this", "more about that",
+        "tell me more",
+        "expand on",
+        "elaborate on",
+    ]
+    q_lower = state["question"].lower()
+    if any(sig in q_lower for sig in FOLLOWUP_SIGNALS) and history_text:
+        # Only fire heuristic if there IS history — a "follow up" with zero
+        # history is still a new question
+        print(f"[intent_node] → FOLLOWUP (heuristic matched + history present)")
+        return {"intent": "FOLLOWUP", "rewritten_question": ""}
 
+    if not history_text:
+        # No usable prior conversation after cleaning — new question
+        print("[intent_node] → NEW_QUESTION (no clean history)")
+        return {"intent": "NEW_QUESTION", "rewritten_question": state["question"]}
 
-def detect_intent_node(state: AgentState):
+    prompt = f"""You are an intent classifier for a multi-turn pharmaceutical chat assistant.
 
-    if len(state["messages"]) <= 1:
-        return {"intent": "NEW_QUESTION"}
-
-    history_text = get_history_text(state["messages"])
-
-    prompt = f"""
-You are an intent classifier.
-
-Conversation:
+Conversation history (most recent last):
 {history_text}
 
-Latest Question:
-{state["question"]}
+New user message: {state['question']}
 
-Return ONLY one label:
-- NEW_QUESTION
-- FOLLOWUP
-"""
+Task: decide if the new message is a FOLLOWUP to the conversation above,
+or a completely independent NEW_QUESTION about a different topic.
 
-    intent = call_llm(prompt)
-    intent = "FOLLOWUP" if "FOLLOWUP" in intent.upper() else "NEW_QUESTION"
+A message is FOLLOWUP if it:
+- References something from the conversation (uses "it", "this", "that", "the document", etc.)
+- Asks for more detail about a previously discussed topic
+- Uses phrases like "what else", "what about", "also", "additionally"
 
-    return {"intent": intent}
+A message is NEW_QUESTION if it:
+- Introduces an entirely new drug, topic, or document not discussed before
+- Could be understood with zero context from this conversation
+
+Reply with exactly one word: FOLLOWUP or NEW_QUESTION"""
+
+    try:
+        verdict = _call_llm(prompt, max_tokens=10).upper().strip()
+        intent: Literal["FOLLOWUP", "NEW_QUESTION"] = (
+            "FOLLOWUP" if "FOLLOWUP" in verdict else "NEW_QUESTION"
+        )
+    except Exception:
+        intent = "NEW_QUESTION"
+
+    print(f"[intent_node] → {intent}")
+    return {
+        "intent": intent,
+        # rewritten_question filled by rewrite_node if FOLLOWUP,
+        # left as original if NEW_QUESTION
+        "rewritten_question": state["question"] if intent == "NEW_QUESTION" else "",
+    }
 
 
-# ==================================================
-# NODE 2: Query Rewriter (for follow-ups)
-# ==================================================
+# ---------------------------------------------------------------------------
+# Node 3 — Query rewriter  (only runs for FOLLOWUP)
+# ---------------------------------------------------------------------------
 
+def rewrite_node(state: AgentState) -> dict:
+    """
+    Rewrites a follow-up question into a fully self-contained query by
+    resolving pronouns, "it", "this", "that", "the document", etc.
 
-def rewrite_question_node(state: AgentState):
+    Example:
+      History: Q: "What are Metformin's side effects?"
+               A: "Nausea, diarrhoea, lactic acidosis..."
+      Follow-up: "What about the dosage?"
+      Rewritten: "What is the recommended dosage for Metformin?"
 
-    history_text = get_history_text(state["messages"])
+    Example:
+      History: Q: "What is described in the document?"
+               A: "The document describes Type 2 diabetes treatment..."
+      Follow-up: "What type of diabetes is described in it?"
+      Rewritten: "What type of diabetes is described in the pharmaceutical document about Metformin?"
+    """
+    messages = state.get("messages", [])
+    # Exclude the current unanswered question if it somehow ended up in state,
+    # then clean malformed pairs before building history text
+    prior_messages = [
+        m for m in messages
+        if not (isinstance(m, HumanMessage) and m.content == state["question"])
+    ]
+    history_text = get_history_text(prior_messages)  # get_history_text cleans internally
 
-    prompt = f"""
-Rewrite the question so it is fully understandable
-without conversation history.
+    prompt = f"""You are a query rewriter for a pharmaceutical document assistant.
 
-Conversation:
+Your job: take a follow-up question and rewrite it as one COMPLETE sentence that makes full
+sense WITHOUT reading the conversation history.
+
+Rules:
+- The rewritten question must be a COMPLETE sentence ending with a question mark
+- Replace ALL pronouns (it, this, that, they, them) with the specific subject from the history
+- Replace vague references like "in it", "in this", "the document" with the actual drug/document name
+- Keep the rewritten question natural and concise
+- Output ONLY the rewritten question — no explanation, no preamble, no partial sentences
+
+Examples:
+  History: talked about Warfarin and Aspirin interaction for Patient A
+  Follow-up: "How much is prescribed in it?"
+  Rewritten: "How much Warfarin and Aspirin is prescribed for Patient A?"
+
+  History: discussed Warfarin contraindications including pregnancy
+  Follow-up: "What is described about pregnancy in it?"
+  Rewritten: "What is described about pregnancy in the Warfarin contraindications document?"
+
+Conversation history:
 {history_text}
 
-Question:
-{state["question"]}
+Follow-up question: {state['question']}
 
-Return ONLY the rewritten question.
-"""
+Rewritten question (complete sentence, ends with ?):"""
 
-    rewritten = call_llm(prompt)
+    try:
+        rewritten = _call_llm(prompt, max_tokens=200)
+        # Strip any accidental preamble the model might add
+        rewritten = rewritten.strip().strip('"').strip("'")
+        print(f"[rewrite_node] '{state['question']}' → '{rewritten}'")
+    except Exception:
+        rewritten = state["question"]   # fallback: use original
+
     return {"rewritten_question": rewritten}
 
 
-# ==================================================
-# NODE 3: Retrieval
-# ==================================================
+# ---------------------------------------------------------------------------
+# Node 4 — Retrieval
+# ---------------------------------------------------------------------------
+
+def retrieve_node(state: AgentState) -> dict:
+    """
+    Retrieves relevant context for the (possibly rewritten) question.
+
+    The actual retrieval logic is in `retrieve_context()` above — that is
+    the only function that changes when KG integration lands (issue #75).
+    """
+    query = state.get("rewritten_question") or state["question"]
+    context_text, source_label = retrieve_context(query)
+
+    return {
+        "context": context_text,
+        "source":  source_label,
+    }
 
 
-def retrieve_node(state: AgentState):
-    query = state["rewritten_question"] or state["question"]
-    context = retrieve_context(query)
-    return {"context": context}
+# ---------------------------------------------------------------------------
+# Node 5 — Answer  (skipped when state.streaming=True)
+# ---------------------------------------------------------------------------
 
-
-# ==================================================
-# NODE 4: Answer Generation
-# ==================================================
-
-
-def answer_node(state: AgentState):
-
-    query = state["rewritten_question"] or state["question"]
-    history_text = get_history_text(state["messages"])
-
-    prompt = f"""
+_ANSWER_PROMPT_TEMPLATE = """\
 You are AIlixir, an AI assistant specialising in pharmaceutical documents.
 
 Use ONLY the provided context to answer. Do not use outside knowledge.
 If the answer is not present in the context, say "I don't know based on the documents."
 
 Context:
-{state["context"]}
+{context}
 
 Conversation:
-{history_text}
+{history}
 
 Question:
-{query}
+{question}
 """
 
-    answer = call_llm(prompt)
-    return {"answer": answer, "messages": [AIMessage(content=answer)]}
+
+def answer_node(state: AgentState) -> dict:
+    """
+    Generates the final answer using Gemini.
+
+    This node is SKIPPED when state.streaming=True — in that case main.py
+    calls Gemini directly with stream=True using the same prompt template
+    (build_answer_prompt) so there is no duplication.
+    """
+    prompt = build_answer_prompt(
+        context=state.get("context", ""),
+        history_text=get_history_text(state.get("messages", [])),
+        question=state.get("rewritten_question") or state["question"],
+    )
+
+    try:
+        answer = _call_llm(prompt)
+    except Exception as exc:
+        answer = f"[Error generating answer: {exc}]"
+
+    # Save the REWRITTEN question (not raw) as the human message so that
+    # the next turn's intent_node and rewrite_node see fully resolved history.
+    # e.g. "What about dosage?" becomes "What is the dosage for Metformin?"
+    saved_question = state.get("rewritten_question") or state["question"]
+
+    return {
+        "answer": answer,
+        "messages": [
+            HumanMessage(content=saved_question),
+            AIMessage(content=answer),
+        ],
+    }
+
+
+def build_answer_prompt(context: str, history_text: str, question: str) -> str:
+    """
+    Exported so main.py can build the IDENTICAL prompt for streaming
+    without duplicating the template string.
+    This is the single source of truth for the answer prompt.
+    """
+    return _ANSWER_PROMPT_TEMPLATE.format(
+        context=context,
+        history=history_text,
+        question=question,
+    )

--- a/ai-playground/chat-app/graph/state.py
+++ b/ai-playground/chat-app/graph/state.py
@@ -1,17 +1,42 @@
-from typing import TypedDict, Annotated
+"""
+graph/state.py
+--------------
+Defines the shared state that flows through every LangGraph node.
 
+Adding a field here is the ONLY change needed to pass new data between nodes.
+
+KG integration note
+-------------------
+When knowledge-graph retrieval lands (issue #75), add fields here:
+  kg_subgraph : str   — which KG subgraph was queried
+  kg_entities : list  — top entities returned by the KG client
+Everything downstream (answer node, API response) will automatically have
+access to them without touching other files.
+"""
+
+from typing import Annotated
+from typing_extensions import TypedDict
 from langgraph.graph.message import add_messages
 
 
 class AgentState(TypedDict):
-    messages: Annotated[list, add_messages]
+    # ── Input ─────────────────────────────────────────────────────────────────
+    question: str                  # raw question from the user
 
-    question: str
+    # ── Pipeline fields (filled by nodes) ────────────────────────────────────
+    intent: str                    # NEW_QUESTION | FOLLOWUP | BLOCKED
+    rewritten_question: str        # disambiguated query used for retrieval
 
-    intent: str
+    # ── Retrieval ─────────────────────────────────────────────────────────────
+    context: str                   # retrieved text passages
+    source: str                    # "documents.json" | "knowledge_graph" | "hybrid"
+                                   # ↑ used for logging and future routing
 
-    rewritten_question: str
+    # ── Answer ────────────────────────────────────────────────────────────────
+    answer: str                    # final answer (filled by answer node OR streamed)
+    streaming: bool                # True  → answer node is skipped (stream endpoint)
+                                   #         Gemini is called directly in main.py
+                                   # False → answer node runs and fills answer
 
-    context: str
-
-    answer: str
+    # ── Memory ────────────────────────────────────────────────────────────────
+    messages: Annotated[list, add_messages]   # full conversation, persisted by Postgres

--- a/ai-playground/chat-app/init_db.py
+++ b/ai-playground/chat-app/init_db.py
@@ -1,0 +1,51 @@
+"""
+init_db.py
+----------
+Local-dev helper to verify the database connection and pre-create the
+LangGraph checkpoint tables before first startup.
+
+In production / CI, tables are created automatically by checkpointer.setup()
+inside graph/builder.py on the first call to build_graph().  You don't need
+to run this script unless you want to validate the connection separately.
+
+Usage
+-----
+    # Make sure .env is configured, then:
+    python init_db.py
+
+Environment variables
+---------------------
+    DB_URI   — full PostgreSQL connection string
+               default: postgresql://postgres:password@localhost:5432/ailixir
+"""
+
+import os
+
+import psycopg
+from dotenv import load_dotenv
+from langgraph.checkpoint.postgres import PostgresSaver
+
+load_dotenv()
+
+DB_URI = os.getenv(
+    "DB_URI",
+    "postgresql://postgres:password@localhost:5432/ailixir",
+)
+
+print(f"Connecting to: {DB_URI.split('@')[-1]}")   # log host/db, not credentials
+
+try:
+    conn = psycopg.connect(DB_URI)
+    print("✅ Database connection OK")
+
+    checkpointer = PostgresSaver(conn)
+    checkpointer.setup()   # creates checkpoints + writes tables if absent
+    print("✅ LangGraph checkpoint tables ready")
+
+    conn.close()
+    print("✅ init_db done — you can now start the API with: uvicorn main:app --reload")
+
+except psycopg.OperationalError as exc:
+    print(f"❌ Could not connect to the database: {exc}")
+    print("   Check your DB_URI in .env and make sure PostgreSQL is running.")
+    raise SystemExit(1) from exc

--- a/ai-playground/chat-app/main.py
+++ b/ai-playground/chat-app/main.py
@@ -1,43 +1,95 @@
 """
 AIlixir – Chat Agent API
+========================
 FastAPI wrapper around the LangGraph RAG agent.
+
+Endpoint summary
+----------------
+GET  /health          — liveness check
+POST /chat            — synchronous, full answer at once
+POST /chat/stream     — streaming via Server-Sent Events (SSE)
+
+Streaming design
+----------------
+The /chat/stream endpoint works in two phases:
+
+  Phase 1 — Graph (runs synchronously, fast):
+    guardrail_node → intent_node → [rewrite_node] → retrieve_node → END
+    Because state.streaming=True, the graph skips answer_node and returns
+    immediately after retrieval.  This gives us:
+      • guardrail result (BLOCKED or allowed)
+      • rewritten question
+      • retrieved context
+      • conversation history
+
+  Phase 2 — Gemini stream:
+    Calls Gemini with stream=True using build_answer_prompt() from nodes.py
+    (single source of truth for the prompt template).
+    Tokens are yielded as SSE "data:" chunks the moment Gemini produces them.
+
+    React Native sees:
+      data: {"type":"meta","intent":"NEW_QUESTION","rewritten_question":"...","source":"documents.json"}\n\n
+      data: {"type":"token","text":"Common "}\n\n
+      data: {"type":"token","text":"side effects "}\n\n
+      ...
+      data: {"type":"done"}\n\n
+
+    This gives the frontend both the token stream AND the metadata it needs
+    (intent, source, rewritten_question) without a second HTTP call.
+
+Why no guardrail duplication
+-----------------------------
+The guardrail_node in graph/nodes.py is the ONLY place that validates
+questions.  main.py never re-implements that logic.  If the guardrail blocks
+the question, state.intent == "BLOCKED" and this file simply forwards the
+refusal message to the client.
 """
 
+from __future__ import annotations
+
+import json
+import os
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import AsyncGenerator
 
-import vertexai
-from vertexai.preview.generative_models import GenerativeModel, GenerationConfig
+from dotenv import load_dotenv
 
+# Load .env from the ai-playground/ folder (one level above chat-app/).
+# This must happen before ANY os.getenv() call in this file or any import
+# that calls os.getenv() at module level (nodes.py, builder.py).
+_ENV_PATH = Path(__file__).resolve().parent / ".env"
+load_dotenv(_ENV_PATH)
+
+import vertexai
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
+from vertexai.preview.generative_models import GenerationConfig, GenerativeModel
 
 from graph.builder import build_graph
 from graph.nodes import (
-    retrieve_context,
-    get_history_text,
     REFUSAL_MESSAGE,
-    BLOCKED_PATTERNS,
+    build_answer_prompt,
+    get_history_text,
 )
 
-import os
-
 # ---------------------------------------------------------------------------
-# Vertex AI (reuse same model as nodes.py)
+# Vertex AI — one model instance for streaming (non-streaming uses nodes.py)
 # ---------------------------------------------------------------------------
 
-PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-LOCATION = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+# Support both VERTEX_PROJECT (your .env) and GOOGLE_CLOUD_PROJECT (GCP standard)
+PROJECT_ID   = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("VERTEX_PROJECT")
+LOCATION     = os.getenv("GOOGLE_CLOUD_LOCATION") or os.getenv("VERTEX_LOCATION", "us-central1")
 GEMINI_MODEL = "gemini-2.5-flash"
-TEMPERATURE = 0.4
+TEMPERATURE  = 0.4
 
 vertexai.init(project=PROJECT_ID, location=LOCATION)
-stream_model = GenerativeModel(model_name=GEMINI_MODEL)
+_stream_model = GenerativeModel(model_name=GEMINI_MODEL)
 
 # ---------------------------------------------------------------------------
-# App lifespan – build the graph once on startup
+# App lifespan — build the graph once on startup
 # ---------------------------------------------------------------------------
 
 _graph = None
@@ -57,14 +109,14 @@ app = FastAPI(
         "Ask questions about uploaded pharmaceutical documents. "
         "Conversations are persisted per session via PostgreSQL."
     ),
-    version="0.1.0",
+    version="0.2.0",
     lifespan=lifespan,
 )
 
-# CORS – required for React Native / web frontends
+# CORS — required for React Native / web frontends
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # tighten to specific domains in production
+    allow_origins=["*"],     # tighten to specific domains in production
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -93,15 +145,65 @@ class ChatRequest(BaseModel):
 
 
 class ChatResponse(BaseModel):
-    answer: str = Field(..., description="The agent's answer.")
-    session_id: str = Field(..., description="Echo of the session_id used.")
-    intent: str = Field(
-        ..., description="Detected intent: NEW_QUESTION, FOLLOWUP, or BLOCKED."
-    )
-    rewritten_question: str = Field(
-        ...,
-        description="Rewritten question used for retrieval.",
-    )
+    answer: str              = Field(..., description="The agent's answer.")
+    session_id: str          = Field(..., description="Echo of the session_id used.")
+    intent: str              = Field(..., description="NEW_QUESTION, FOLLOWUP, or BLOCKED.")
+    rewritten_question: str  = Field(..., description="Query used for retrieval.")
+    source: str              = Field(..., description="Retrieval source (documents.json / knowledge_graph / hybrid).")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_prior_messages(session_id: str) -> list:
+    """
+    Explicitly fetch the persisted message history for this session from the
+    Postgres checkpoint BEFORE invoking the graph.
+
+    Why this is necessary
+    ---------------------
+    LangGraph's add_messages reducer merges the checkpoint's messages with
+    whatever we pass as "messages" in the initial state. However, in some
+    LangGraph versions the merge only happens at the reducer level AFTER the
+    first node has already executed — meaning guardrail_node and intent_node
+    would see an empty list. Fetching history explicitly and passing it in
+    the initial state guarantees every node sees the full prior conversation
+    from the very first node.
+    """
+    if _graph is None:
+        return []
+    try:
+        config = _graph_config(session_id)
+        snapshot = _graph.get_state(config)
+        if snapshot and snapshot.values:
+            return snapshot.values.get("messages", [])
+    except Exception:
+        pass
+    return []
+
+
+def _build_initial_state(question: str, streaming: bool, prior_messages: list) -> dict:
+    """Returns a clean initial AgentState dict for one graph invocation."""
+    return {
+        "question":           question,
+        "intent":             "",
+        "rewritten_question": "",
+        "context":            "",
+        "source":             "",
+        "answer":             "",
+        "streaming":          streaming,
+        "messages":           prior_messages,   # ← history loaded explicitly
+    }
+
+
+def _graph_config(session_id: str) -> dict:
+    return {"configurable": {"thread_id": session_id}}
+
+
+def _require_graph():
+    if _graph is None:
+        raise HTTPException(status_code=503, detail="Agent not initialised yet.")
 
 
 # ---------------------------------------------------------------------------
@@ -118,25 +220,20 @@ def health():
 @app.post("/chat", response_model=ChatResponse, tags=["Chat"])
 def chat(body: ChatRequest):
     """
-    Standard request/response — full answer returned at once.
+    Synchronous endpoint — full answer returned at once.
     Use for testing, scripts, or non-streaming clients.
+
+    The graph runs all five nodes:
+      guardrail → intent → [rewrite] → retrieve → answer
     """
-    if _graph is None:
-        raise HTTPException(status_code=503, detail="Agent not initialised yet.")
+    _require_graph()
 
-    initial_state = {
-        "question": body.question,
-        "intent": "",
-        "rewritten_question": "",
-        "context": "",
-        "answer": "",
-        "messages": [],
-    }
-
-    config = {"configurable": {"thread_id": body.session_id}}
-
+    prior_messages = _get_prior_messages(body.session_id)
     try:
-        result = _graph.invoke(initial_state, config=config)
+        result = _graph.invoke(
+            _build_initial_state(body.question, streaming=False, prior_messages=prior_messages),
+            config=_graph_config(body.session_id),
+        )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
@@ -145,6 +242,7 @@ def chat(body: ChatRequest):
         session_id=body.session_id,
         intent=result.get("intent", ""),
         rewritten_question=result.get("rewritten_question") or body.question,
+        source=result.get("source", "documents.json"),
     )
 
 
@@ -153,126 +251,93 @@ async def chat_stream(body: ChatRequest):
     """
     Streaming endpoint — tokens arrive word by word from Gemini in real time.
 
-    How it works:
-      1. Guardrail check (blocks injection / off-topic) — instant refusal if blocked
-      2. Runs the full graph (intent → rewrite → retrieve) to get context
-      3. Calls Gemini with stream=True so tokens are sent to the client as generated
+    SSE format
+    ----------
+    Each message is a JSON object on a "data:" line:
 
-    Response format: Server-Sent Events (SSE)
-      Each chunk: "data: <text>\\n\\n"
-      End signal:  "data: [DONE]\\n\\n"
+      data: {"type":"meta","intent":"NEW_QUESTION","rewritten_question":"...","source":"..."}\n\n
+      data: {"type":"token","text":"Some text chunk"}\n\n
+      data: {"type":"done"}\n\n
 
-    React Native usage:
-      const res = await fetch('/chat/stream', { method: 'POST', body: ... })
+    On error or block:
+      data: {"type":"error","text":"..."}\n\n
+      data: {"type":"blocked","text":"..."}\n\n
+
+    React Native example
+    --------------------
+      const res = await fetch('/chat/stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question, session_id }),
+      })
       const reader = res.body.getReader()
+      const decoder = new TextDecoder()
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
-        const chunk = new TextDecoder().decode(value)
-        if (chunk.includes('[DONE]')) break
-        appendToUI(chunk.replace('data: ', ''))
+        const raw = decoder.decode(value)
+        // each SSE chunk starts with "data: "
+        for (const line of raw.split('\\n')) {
+          if (!line.startsWith('data: ')) continue
+          const msg = JSON.parse(line.slice(6))
+          if (msg.type === 'meta')    setMeta(msg)
+          if (msg.type === 'token')   appendText(msg.text)
+          if (msg.type === 'done')    markComplete()
+          if (msg.type === 'blocked') showRefusal(msg.text)
+          if (msg.type === 'error')   showError(msg.text)
+        }
       }
     """
-    if _graph is None:
-        raise HTTPException(status_code=503, detail="Agent not initialised yet.")
+    _require_graph()
 
     async def token_generator() -> AsyncGenerator[str, None]:
-        question = body.question
-        q_lower = question.lower()
 
-        # ------------------------------------------------------------------
-        # Step 1: Guardrail — run before touching the graph
-        # ------------------------------------------------------------------
-        pharma_keywords = [
-            "drug",
-            "medicine",
-            "patient",
-            "dose",
-            "side effect",
-            "interaction",
-            "contraindication",
-            "trial",
-            "clinical",
-            "treatment",
-            "diabetes",
-            "warfarin",
-            "metformin",
-            "aspirin",
-            "bleeding",
-            "adverse",
-            "hba1c",
-            "summarize",
-            "summary",
-            "explain",
-            "what",
-            "how",
-            "why",
-            "when",
-            "document",
-            "report",
-            "tell",
-            "describe",
-        ]
+        def sse(payload: dict) -> str:
+            """Encode a dict as a single SSE data line."""
+            return f"data: {json.dumps(payload)}\n\n"
 
-        if any(p in q_lower for p in BLOCKED_PATTERNS) or not any(
-            kw in q_lower for kw in pharma_keywords
-        ):
-            yield f"data: {REFUSAL_MESSAGE}\n\n"
-            yield "data: [DONE]\n\n"
-            return
-
-        # ------------------------------------------------------------------
-        # Step 2: Run graph (guardrail → intent → rewrite → retrieve)
-        #         but grab context + history before streaming the answer
-        # ------------------------------------------------------------------
-        initial_state = {
-            "question": question,
-            "intent": "",
-            "rewritten_question": "",
-            "context": "",
-            "answer": "",
-            "messages": [],
-        }
-        config = {"configurable": {"thread_id": body.session_id}}
-
+        # ── Phase 1: run the graph up to (and including) retrieve_node ────────
+        # streaming=True tells the graph to skip answer_node and return early.
+        # The guardrail, intent, rewrite, and retrieve nodes all run normally.
+        prior_messages = _get_prior_messages(body.session_id)
         try:
-            result = _graph.invoke(initial_state, config=config)
+            result = _graph.invoke(
+                _build_initial_state(body.question, streaming=True, prior_messages=prior_messages),
+                config=_graph_config(body.session_id),
+            )
         except Exception as exc:
-            yield f"data: [ERROR] {str(exc)}\n\n"
+            yield sse({"type": "error", "text": str(exc)})
             return
 
-        # If guardrail blocked inside the graph
+        # ── Guardrail fired inside the graph ──────────────────────────────────
         if result.get("intent") == "BLOCKED":
-            yield f"data: {result['answer']}\n\n"
-            yield "data: [DONE]\n\n"
+            yield sse({"type": "blocked", "text": result.get("answer", REFUSAL_MESSAGE)})
+            yield sse({"type": "done"})
             return
 
-        query = result.get("rewritten_question") or question
-        context = result.get("context", "")
-        history_text = get_history_text(result.get("messages", []))
+        # ── Emit metadata so the frontend has it immediately ──────────────────
+        # The frontend receives this BEFORE the first token — it can use it to
+        # show intent indicators, source badges, etc. without waiting for the
+        # full answer.
+        rewritten_q = result.get("rewritten_question") or body.question
+        yield sse({
+            "type":               "meta",
+            "intent":             result.get("intent", "NEW_QUESTION"),
+            "rewritten_question": rewritten_q,
+            "source":             result.get("source", "documents.json"),
+        })
 
-        # ------------------------------------------------------------------
-        # Step 3: Stream the answer directly from Gemini
-        # ------------------------------------------------------------------
-        prompt = f"""
-You are AIlixir, an AI assistant specialising in pharmaceutical documents.
-
-Use ONLY the provided context to answer. Do not use outside knowledge.
-If the answer is not present in the context, say "I don't know based on the documents."
-
-Context:
-{context}
-
-Conversation:
-{history_text}
-
-Question:
-{query}
-"""
+        # ── Phase 2: stream the answer directly from Gemini ───────────────────
+        # We use build_answer_prompt() from nodes.py — same template the
+        # answer_node uses — so there is zero prompt duplication.
+        prompt = build_answer_prompt(
+            context=result.get("context", ""),
+            history_text=get_history_text(result.get("messages", [])),
+            question=rewritten_q,
+        )
 
         try:
-            # stream=True makes Gemini return chunks as they are generated
-            responses = stream_model.generate_content(
+            responses = _stream_model.generate_content(
                 prompt,
                 generation_config=GenerationConfig(
                     temperature=TEMPERATURE,
@@ -284,18 +349,19 @@ Question:
             for chunk in responses:
                 text = chunk.text
                 if text:
-                    yield f"data: {text}\n\n"
+                    yield sse({"type": "token", "text": text})
 
-            yield "data: [DONE]\n\n"
+            yield sse({"type": "done"})
 
         except Exception as exc:
-            yield f"data: [ERROR] {str(exc)}\n\n"
+            yield sse({"type": "error", "text": str(exc)})
 
     return StreamingResponse(
         token_generator(),
         media_type="text/event-stream",
         headers={
-            "X-Accel-Buffering": "no",  # stops nginx from buffering
-            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",    # stops nginx from buffering SSE
+            "Cache-Control":     "no-cache",
+            "Connection":        "keep-alive",
         },
     )

--- a/ai-playground/chat-app/readme.md
+++ b/ai-playground/chat-app/readme.md
@@ -1,22 +1,25 @@
 # AIlixir Chat Agent
 
-A RAG (Retrieval-Augmented Generation) chat agent built with **LangGraph**, **Gemini (Vertex AI)**, and **FastAPI**. Users can ask natural-language questions about uploaded pharmaceutical documents. Conversation history is persisted per session in **PostgreSQL**.
+A RAG (Retrieval-Augmented Generation) chat agent built with **LangGraph**, **Gemini 2.5 Flash (Vertex AI)**, and **FastAPI**. Users ask natural-language questions about uploaded pharmaceutical documents. Conversation history is persisted per session in **PostgreSQL**.
 
 ---
 
 ## Folder Structure
 
 ```
-chat-app/
-├── main.py                  # FastAPI application & endpoints
-├── documents.json           # Source documents for retrieval
-├── requirements.txt         # Python dependencies
-├── .env.example             # Safe template to commit
-└── graph/
-    ├── __init__.py
-    ├── builder.py           # LangGraph graph definition & Postgres checkpointer
-    ├── nodes.py             # All graph nodes: guardrail, intent, rewrite, retrieve, answer
-    └── state.py             # AgentState TypedDict
+ai-playground/
+└── chat-app/
+    ├── main.py              # FastAPI app — /health, /chat, /chat/stream endpoints
+    ├── init_db.py           # Local-dev helper to verify DB connection & pre-create tables
+    ├── documents.json       # Source documents for retrieval
+    ├── requirements.txt     # Python dependencies
+    ├── .env                 # Your local config (never commit this)
+    ├── .env.example         # Safe template to commit
+    └── graph/
+        ├── __init__.py
+        ├── builder.py       # LangGraph graph definition & Postgres checkpointer
+        ├── nodes.py         # All graph nodes + shared helpers used by main.py
+        └── state.py         # AgentState TypedDict — the single shared state schema
 ```
 
 ---
@@ -24,35 +27,53 @@ chat-app/
 ## Architecture
 
 ```
-User Request (POST /chat)
+User Request (POST /chat or POST /chat/stream)
         │
         ▼
-  [ Guardrail Node ]  ──── BLOCKED ──▶  END (refusal message)
+  [ Guardrail Node ]
+        │  checks for prompt-injection patterns
+        │  + off-topic intent via LLM classifier
+        │
+   BLOCKED ──────────────────────────────────────▶ END (refusal message)
         │
       ALLOWED
         │
         ▼
-  [ Intent Detection ]
+  [ Intent Node ]
+        │  LLM-based + heuristic classifier
         │
    ┌────┴────┐
    │         │
 FOLLOWUP  NEW_QUESTION
    │         │
    ▼         │
-[ Query      │
-  Rewriter ] │
-   │         │
+[ Rewrite    │
+  Node ]     │   resolves pronouns & vague references
+   │         │   into a self-contained query
    └────┬────┘
         ▼
-  [ Retrieval Node ]   ◀── documents.json (keyword search)
-        │                   (swap for Knowledge Graph later)
-        ▼
-  [ Answer Node ]      ◀── Gemini 2.5 Flash via Vertex AI
+  [ Retrieve Node ]   ◀── keyword search over documents.json
+        │                  (swap point for Knowledge Graph — issue #75)
+        │
+   streaming=True ──────────────────────────────▶ END
+        │            main.py streams Gemini directly
+   streaming=False
         │
         ▼
-     Response
-  (saved to Postgres)
+  [ Answer Node ]     ◀── Gemini 2.5 Flash via Vertex AI (non-streaming)
+        │
+        ▼
+  Response saved to Postgres (LangGraph PostgresSaver)
 ```
+
+### Streaming vs. Non-Streaming
+
+The graph has two paths after the retrieve node, controlled by `state.streaming`:
+
+- **`POST /chat`** (non-streaming): the graph runs all five nodes including `answer_node`. The full answer is returned in a single JSON response.
+- **`POST /chat/stream`** (streaming): the graph runs up to and including `retrieve_node`, then exits. `main.py` then calls Gemini with `stream=True` and pipes tokens directly to the client as Server-Sent Events. This eliminates any wasted non-streaming LLM call inside the graph.
+
+Both paths use the same `build_answer_prompt()` function from `nodes.py` — there is no prompt duplication.
 
 ---
 
@@ -62,7 +83,7 @@ FOLLOWUP  NEW_QUESTION
 |---|---|
 | Python | 3.10+ |
 | PostgreSQL | 14+ |
-| Google Cloud project | with Vertex AI API enabled |
+| Google Cloud project | Vertex AI API enabled |
 
 ---
 
@@ -71,7 +92,7 @@ FOLLOWUP  NEW_QUESTION
 ### 1. Clone and create a virtual environment
 
 ```bash
-cd chat-app
+cd ai-playground/chat-app
 python -m venv venv
 
 # Windows
@@ -91,22 +112,21 @@ pip install -r requirements.txt
 
 If PostgreSQL is not installed yet:
 
-- **Windows**: Download and install from https://www.postgresql.org/download/windows/  
-  During installation, set a password for the `postgres` user — remember it.
+- **Windows**: Download from https://www.postgresql.org/download/windows/ and set a password for the `postgres` user during installation.
 - **macOS**: `brew install postgresql@14 && brew services start postgresql@14`
 - **Linux (Ubuntu/Debian)**: `sudo apt install postgresql && sudo systemctl start postgresql`
 
-Once installed, open a terminal and connect to PostgreSQL:
+Once installed, open a terminal and create the database:
 
 ```bash
-# Windows (use psql from the Start menu or add it to PATH)
+# Windows (run psql from Start menu or add it to PATH)
 psql -U postgres
 
 # macOS / Linux
 sudo -u postgres psql
 ```
 
-Inside the psql shell, create the database:
+Inside the psql shell:
 
 ```sql
 CREATE DATABASE ailixir;
@@ -115,35 +135,33 @@ CREATE DATABASE ailixir;
 
 ### 4. Configure environment variables
 
-Copy the example file and fill in your values:
-
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env`:
+Edit `.env` with your values:
 
 ```env
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 GOOGLE_CLOUD_LOCATION=us-central1
+VERTEX_PROJECT_ID=your-vertex-project-id
 DB_URI=postgresql://postgres:YOUR_PASSWORD@localhost:5432/ailixir
 ```
 
-Replace `YOUR_PASSWORD` with the password you set during PostgreSQL installation.
+Both `GOOGLE_CLOUD_PROJECT` and `VERTEX_PROJECT_ID` are supported. The code reads whichever is present, so you can use either the standard Google Cloud SDK convention or the Vertex-specific name.
 
-> The `DB_URI` format is: `postgresql://<user>:<password>@<host>:<port>/<database>`  
-> Default PostgreSQL user is `postgres`, default port is `5432`.
-
-Then update `graph/builder.py` to read from the environment instead of hardcoding:
-
-```python
-import os
-DB_URI = os.getenv("DB_URI", "postgresql://postgres:password@localhost:5432/ailixir")
-```
+> **DB_URI format:** `postgresql://<user>:<password>@<host>:<port>/<database>`  
+> Default user is `postgres`, default port is `5432`.
 
 ### 5. Database tables
 
-The required tables (`checkpoints`, `writes`) are created **automatically** on first startup — no manual SQL needed. LangGraph's `checkpointer.setup()` handles this.
+The required tables (`checkpoints`, `writes`) are created **automatically** on first startup by LangGraph's `checkpointer.setup()` inside `builder.py`. No manual SQL is needed.
+
+If you want to verify the connection and pre-create the tables before starting the server (useful in local dev), run:
+
+```bash
+python init_db.py
+```
 
 ### 6. Run the API
 
@@ -152,19 +170,21 @@ uvicorn main:app --reload --port 8000
 ```
 
 The API is now live at `http://localhost:8000`.  
-Interactive docs (Swagger UI): `http://localhost:8000/docs`
+Swagger UI (interactive docs): `http://localhost:8000/docs`
 
 ---
 
 ## API Endpoints
 
 ### `GET /health`
+
 Liveness check. Returns `{"status": "ok"}`.
 
 ---
 
 ### `POST /chat`
-Send a question to the agent.
+
+Synchronous — full answer returned at once. All five graph nodes run.
 
 **Request body:**
 ```json
@@ -177,7 +197,7 @@ Send a question to the agent.
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `question` | string | ✅ | Your question (1–2000 chars) |
-| `session_id` | string | ❌ | Conversation thread ID. Reuse across turns to keep memory. Defaults to `"default-session"` |
+| `session_id` | string | ❌ | Conversation thread ID. Reuse across turns to maintain context. Defaults to `"default-session"` |
 
 **Response:**
 ```json
@@ -185,7 +205,8 @@ Send a question to the agent.
   "answer": "Common side effects of Metformin include nausea, diarrhoea...",
   "session_id": "user-42",
   "intent": "NEW_QUESTION",
-  "rewritten_question": "What are the side effects of Metformin?"
+  "rewritten_question": "What are the side effects of Metformin?",
+  "source": "documents.json"
 }
 ```
 
@@ -194,68 +215,135 @@ Send a question to the agent.
 | `answer` | Agent's answer grounded in documents |
 | `session_id` | Echo of the session used |
 | `intent` | `NEW_QUESTION`, `FOLLOWUP`, or `BLOCKED` |
-| `rewritten_question` | Disambiguated question used for retrieval (follow-ups only) |
+| `rewritten_question` | Disambiguated query used for retrieval |
+| `source` | Retrieval source — currently always `documents.json` |
+
+---
+
+### `POST /chat/stream`
+
+Streaming via Server-Sent Events. The graph runs up to `retrieve_node`, then Gemini streams tokens directly to the client.
+
+Same request body as `/chat`.
+
+**SSE event sequence:**
+
+```
+data: {"type":"meta","intent":"NEW_QUESTION","rewritten_question":"...","source":"documents.json"}
+
+data: {"type":"token","text":"Common "}
+
+data: {"type":"token","text":"side effects "}
+
+...
+
+data: {"type":"done"}
+```
+
+On a blocked question:
+```
+data: {"type":"blocked","text":"I can only answer questions about pharmaceutical documents..."}
+
+data: {"type":"done"}
+```
+
+On an error:
+```
+data: {"type":"error","text":"<error message>"}
+```
+
+The `meta` event arrives **before** the first token, so the frontend can display intent indicators and source badges immediately without waiting for the full answer.
+
+**React Native example:**
+
+```javascript
+const res = await fetch('https://your-api-domain.com/chat/stream', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ question: userInput, session_id: userId }),
+});
+
+const reader = res.body.getReader();
+const decoder = new TextDecoder();
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  const raw = decoder.decode(value);
+  for (const line of raw.split('\n')) {
+    if (!line.startsWith('data: ')) continue;
+    const msg = JSON.parse(line.slice(6));
+    if (msg.type === 'meta')    setMeta(msg);
+    if (msg.type === 'token')   appendText(msg.text);
+    if (msg.type === 'done')    markComplete();
+    if (msg.type === 'blocked') showRefusal(msg.text);
+    if (msg.type === 'error')   showError(msg.text);
+  }
+}
+```
+
+---
+
+## Graph Nodes
+
+All node logic lives in `graph/nodes.py`. Constants and helpers used by `main.py` are imported from there — no logic is duplicated.
+
+| Node | Purpose |
+|---|---|
+| `guardrail_node` | Blocks prompt-injection patterns and off-topic questions. Sets `intent="BLOCKED"` and short-circuits to END if triggered. |
+| `intent_node` | Classifies the question as `NEW_QUESTION` or `FOLLOWUP` using a heuristic check first, then an LLM call if needed. |
+| `rewrite_node` | Rewrites follow-up questions into fully self-contained queries by resolving pronouns and vague references. Only runs for `FOLLOWUP`. |
+| `retrieve_node` | Performs keyword search over `documents.json` and populates `state.context` and `state.source`. |
+| `answer_node` | Calls Gemini to generate the final answer. Skipped when `state.streaming=True`. |
 
 ---
 
 ## Guardrails
 
-All questions pass through a guardrail node **before** reaching the LLM:
+Questions pass through `guardrail_node` before any LLM call:
 
-- **Prompt injection** — blocks patterns like `"ignore previous instructions"`, `"pretend you are"`, `"jailbreak"`, etc.
-- **Off-topic queries** — blocks questions with no pharmaceutical/document relevance using keyword heuristics.
+**Prompt-injection detection** blocks patterns such as `"ignore previous instructions"`, `"pretend you are"`, `"jailbreak"`, `"act as"`, `"bypass"`, `"developer mode"`, and similar.
 
-Blocked requests return a safe refusal message and never invoke the LLM.
+**Off-topic detection** uses an LLM classifier to reject questions with no pharmaceutical or document relevance.
+
+Blocked requests return `REFUSAL_MESSAGE` and never invoke the LLM.
 
 ---
 
 ## Conversation Memory
 
-Memory is handled automatically by LangGraph's `PostgresSaver`. Each unique `session_id` maps to an independent conversation thread stored in PostgreSQL. No manual history management is required.
+Memory is managed automatically by LangGraph's `PostgresSaver`. Each unique `session_id` maps to an independent thread stored in PostgreSQL. The full message history is loaded explicitly before each graph invocation so every node — including `guardrail_node` and `intent_node` — sees the complete prior conversation from the first node onwards.
+
+Message history is stored using the rewritten question (not the raw follow-up) so that future intent classification and query rewriting always work from fully resolved context.
 
 ---
 
-## Connecting a Frontend (React Native)
+## Retrieval
 
-CORS is fully enabled — all origins, methods, and headers are allowed. From React Native:
+Retrieval currently uses keyword scoring over `documents.json`. Each document's content is scored by the number of query words it contains; the top-3 documents are concatenated and passed as context to Gemini.
 
-```javascript
-const response = await fetch('https://your-api-domain.com/chat', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({
-    question: userInput,
-    session_id: userId,
-  }),
-});
-const data = await response.json();
-console.log(data.answer);
-```
+### Extending to a Knowledge Graph (issue #75)
 
----
-
-## Running Tests
-
-```bash
-pip install pytest httpx
-pytest tests/test_chat.py -v
-```
-
-Tests use mocks for Vertex AI and PostgreSQL — no real GCP credentials or database needed to run them.
-
----
-
-## Extending with a Knowledge Graph
-
-Retrieval currently uses keyword search over `documents.json`. To integrate a knowledge graph (issue #75), replace the `retrieve_context()` function in `graph/nodes.py`:
+The only function that changes is `retrieve_context()` in `graph/nodes.py`:
 
 ```python
-def retrieve_context(query: str, top_k: int = 3) -> str:
-    # Replace with your KG client query
+def retrieve_context(query: str, top_k: int = 3) -> tuple[str, str]:
+    # Replace with your KG client call
     results = kg_client.query(query)
-    return format_kg_results(results)
+    return format_kg_results(results), "knowledge_graph"
 ```
 
-No other files need to change.
+The return signature `(context_text, source_label)` must stay the same. No other file needs to change. New state fields for KG metadata (subgraph, entities) can be added to `graph/state.py` — all downstream nodes and the API response will have access to them automatically.
 
 ---
+
+## Environment Variable Reference
+
+| Variable | Description | Default |
+|---|---|---|
+| `GOOGLE_CLOUD_PROJECT` | GCP project ID (standard SDK name) | — |
+| `GOOGLE_CLOUD_LOCATION` | Vertex AI region | `us-central1` |
+| `VERTEX_PROJECT_ID` | GCP project ID (Vertex-specific alias) | — |
+| `DB_URI` | Full PostgreSQL connection string | `postgresql://postgres:password@localhost:5432/ailixir` |
+
+`GOOGLE_CLOUD_PROJECT` and `VERTEX_PROJECT_ID` are interchangeable — the code reads whichever is set.


### PR DESCRIPTION
## feat(chat-app): LangGraph RAG chat agent with streaming API

Closes #115 · Parent of #75

### What
Replaces the single-file prototype with a production-ready LangGraph pipeline and FastAPI wrapper.

**Pipeline:** `guardrail_node → intent_node → [rewrite_node] → retrieve_node → answer_node`

- **Guardrail** — injection pattern match + LLM-based off-topic classification. Single source of truth, never duplicated in `main.py`.
- **Intent** — classifies each turn as `NEW_QUESTION` or `FOLLOWUP` from conversation history.
- **Rewrite** — resolves pronouns and vague references (`"it"`, `"the document"`) into self-contained queries. Only runs on follow-ups.
- **Retrieve** — keyword search over `documents.json`. Single swap point for KG integration (#75): replace `retrieve_context()` only.
- **Answer** — Gemini 2.5 Flash via Vertex AI. Skipped on streaming requests.

**Endpoints**
- `POST /chat` — synchronous full answer
- `POST /chat/stream` — SSE stream; frontend receives a `meta` chunk (intent, rewritten question, source) before tokens start flowing

**Memory** — `PostgresSaver` persists conversation history per `session_id` in PostgreSQL. Tables auto-created on first startup.

### Acceptance criteria
| | |
|---|---|
| LLM endpoint with Gemini | ✅ `POST /chat` |
| KG-ready framework | ✅ `retrieve_context()` is the only function that changes for #75 |
| React Native / streaming | ✅ `POST /chat/stream` SSE with structured JSON chunks |
| Pre-prompt guardrails | ✅ `guardrail_node` — injection patterns + LLM classifier |

### Test
```bash
uvicorn main:app --reload --port 8000
# Swagger UI: http://localhost:8000/docs
```
Send turn 1 (`"What are the side effects of Metformin?"`) then turn 2 (`"What type of diabetes is mentioned in it?"`) with the same `session_id`. Turn 2 should return `intent: FOLLOWUP` and a fully resolved `rewritten_question`.