### PR TITLE
fix(#226): expose graph_query and entities_query on DocumentResponse

### DIFF
--- a/Backend/api/main.py
+++ b/Backend/api/main.py
@@ -364,6 +364,20 @@ class DocumentResponse(BaseModel):
     # diagnostic — display a generic failure UI and surface this only to
     # support, alongside the response's `X-Request-ID` header.
     error: str | None = None
+    # Worker-written Cypher templates for graph visualisation. Null until the
+    # pipeline writes them at status=extracted.
+    #
+    # `graph_query`    — full entity-relationship subgraph for the patient
+    #                    (group_id-scoped). Same query value for every
+    #                    document owned by the same user.
+    # `entities_query` — entities linked to THIS document's episode only.
+    #
+    # NOTE — known issue: these strings are built with f-string interpolation
+    # of values that ultimately come from the LLM extraction step. A future
+    # PR should replace them with parameterised server-side endpoints (see
+    # the design notes on PR #226 review).
+    graph_query: str | None = None
+    entities_query: str | None = None
 
 
 class DocumentListItem(BaseModel):
@@ -635,6 +649,8 @@ def _to_document_response(document: Document) -> DocumentResponse:
         cypher_download_expires_at=cypher_download_expires_at,
         processing_step=document.processing_step,
         error=document.error,
+        graph_query=document.graph_query,
+        entities_query=document.entities_query,
     )
 
 


### PR DESCRIPTION
PR #226 added these fields to the internal Document model and wrote them to Firestore, but never extended the API's wire model (DocumentResponse). Pydantic v2 silently drops fields not declared on the response model, so the GET /documents/{id} endpoint returned shape unchanged — the frontend could not see the new data even though the worker wrote it correctly.

Surgical fix: declare the two fields on DocumentResponse and pass them through in _to_document_response(). Both are optional and default to null, so older worker revisions (or any document whose pipeline didn't reach status=extracted) continue to serialise cleanly.

Verified: patched _to_document_response() against a real Firestore record (doc_531033f285a4454e9a82994b04fdd1af) — both fields surface in the serialised response with the exact Cypher strings the worker wrote.

Out of scope for this PR (separate tickets):
  - Replace f-string Cypher interpolation with parameterised server-side endpoints. Today `document_date` (LLM-extracted) flows directly into the query string with no escaping; a malformed date breaks Cypher syntax and a malicious one is injectable.
  - Add `m.group_id = $uid` guard to the entity-graph query to harden cross-user isolation if Graphiti ever shares nodes across group_ids.