### PR TITLE
feat(scrapers): Implement standalone PubMed scraping subsystem

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -28,6 +28,16 @@ NEO4J_URI=bolt://localhost:7687          # local Docker  — or — neo4j+s://xx
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=your_secure_password
 
+# ── Scrapers subsystem (AstraDB vector store; see scrapers/README.md) ─────────
+# Decoupled from the Neo4j graph. Only needed to run `python -m scrapers.run_pubmed`.
+OPEN_AI_API=sk-...                    # OpenAI key — used for embeddings
+ASTRA_DB_API_ENDPOINT=https://<db-id>-<region>.apps.astra.datastax.com
+ASTRA_DB_TOKEN=AstraCS:...
+ASTRA_DB_NAMESPACE=default_keyspace
+ASTRA_DB_COLLECTION=health_ai
+NCBI_ENTREZ_EMAIL=you@example.com     # optional; NCBI asks callers to identify themselves
+NCBI_API_KEY=...                      # optional; raises the PubMed rate limit
+
 # ── Local dev / testing ───────────────────────────────────────────────────────
 TEST_USER_EMAIL=test@ailixir.dev
 TEST_USER_PASSWORD=test1234

--- a/Backend/scrapers/.gitignore
+++ b/Backend/scrapers/.gitignore
@@ -1,0 +1,2 @@
+# Scraped artefacts: raw JSON, temp PDFs, dedup index, logs.
+data/

--- a/Backend/scrapers/README.md
+++ b/Backend/scrapers/README.md
@@ -1,0 +1,590 @@
+# Backend Scrapers Documentation
+
+`Backend/scrapers` is a standalone literature-ingestion subsystem. It scrapes
+external public medical literature, converts article text into chunks, embeds those
+chunks with OpenAI embeddings, and stores them in an AstraDB vector collection.
+
+The scraper corpus is global reference knowledge. It is intentionally separate from
+the app's per-user document pipeline and from the Neo4j / Graphiti patient knowledge
+graph.
+
+At the moment, the only implemented source is PubMed.
+
+## High-Level Purpose
+
+The main backend app extracts a patient's own medical documents into a per-user
+knowledge graph. The scraper subsystem solves a different problem: it builds a
+shared background literature corpus that can later be retrieved by disease/topic.
+
+That means:
+
+- Patient uploads do not call this package.
+- `api/`, `workers/`, and `shared/` do not depend on scraper execution.
+- Scraper output is stored in AstraDB, not Neo4j.
+- Deduplication is global, so the same paper is not embedded repeatedly.
+- Disease tags such as `prostate_cancer` are stored as metadata on chunks for later
+  retrieval filtering.
+
+## Architecture Illustration
+
+```mermaid
+flowchart LR
+    CLI[CLI runner\nrun_pubmed.py / run_topics.py]
+    Target[PubMedTarget\nkeywords + max_results + optional disease]
+    Search[PubMed Entrez search\nfree full text filter]
+    LedgerCheck[Dedup ledger\nFirestore or local JSON]
+    Scraper[PubMedScraper]
+    Metadata[Entrez metadata\nPMID, DOI, title, authors,\ndate, abstract]
+    PDF[paperscraper PDF download]
+    Text[pypdf text extraction]
+    Fallback[Abstract fallback\nwhen PDF text unavailable]
+    Splitter[RecursiveCharacterTextSplitter\n512 chars, 25 overlap]
+    Embeddings[OpenAIEmbeddings]
+    Astra[AstraDB vector store]
+    LedgerWrite[Record ingested paper\nPMID, diseases, chunk count]
+    Raw[Raw JSON archive\nscrapers/data/pubmed/raw]
+    Logs[Log file\nscrapers/data/log/log.txt]
+
+    CLI --> Target
+    Target --> Search
+    Search --> LedgerCheck
+    LedgerCheck -->|new PMIDs only| Scraper
+    Scraper --> Metadata
+    Metadata --> PDF
+    PDF --> Text
+    Text -->|if full text exists| Splitter
+    Metadata --> Fallback
+    Fallback -->|if PDF missing/empty| Splitter
+    Scraper --> Raw
+    Splitter --> Embeddings
+    Embeddings --> Astra
+    Astra --> LedgerWrite
+    Scraper --> Logs
+```
+
+## Runtime Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant Runner as CLI runner
+    participant Target as PubMedTarget
+    participant PubMed as PubMed / Entrez
+    participant Ledger as Dedup ledger
+    participant Scraper as PubMedScraper
+    participant Store as AstraDB
+
+    User->>Runner: python -m scrapers.run_pubmed --keywords ... --max-results ...
+    Runner->>Target: create target
+    Target->>PubMed: search_free_fulltext(query)
+    PubMed-->>Target: candidate PMIDs
+    Target->>Ledger: filter_new(candidate PMIDs)
+    Ledger-->>Target: PMIDs not yet embedded
+    Target-->>Runner: PubMedScraper instances
+    loop each new PMID
+        Runner->>Scraper: scrape_and_save()
+        Scraper->>PubMed: fetch_details(PMID)
+        PubMed-->>Scraper: XML metadata
+        Scraper->>Scraper: derive DOI/title/authors/date/abstract
+        Scraper->>Scraper: download PDF and extract text
+        Scraper->>Scraper: chunk full text or abstract fallback
+        Scraper->>Store: add_documents(chunks + metadata)
+        Scraper->>Ledger: record(PMID, disease, chunks, full_text)
+    end
+```
+
+## Package Map
+
+| File | Responsibility |
+| --- | --- |
+| `__init__.py` | Package bootstrap. Loads `Backend/.env`, defines package-local data directories, creates the PubMed index file when missing. |
+| `base_target.py` | Abstract target contract. A target describes what should be scraped and returns scraper instances. |
+| `pubmed_target.py` | PubMed-specific target containing search keywords, max result count, and optional disease metadata tag. |
+| `base_scraper.py` | Abstract scraper workflow: scrape, save raw JSON, convert to LangChain documents, save vectors, record dedup status. |
+| `pubmed.py` | PubMed implementation. Searches PubMed, fetches metadata, downloads PDFs, extracts text, chunks content, builds document metadata. |
+| `splitter.py` | Text splitting helper using LangChain's `RecursiveCharacterTextSplitter`. |
+| `ledger.py` | Dedup adapter. Uses Firestore `literature_papers` when available, otherwise falls back to local `data/pubmed/index.json`. |
+| `patient_topics.py` | Reads a patient's Graphiti/Neo4j Diagnosis nodes and maps them to curated disease topics. |
+| `topics.py` | Curated disease/topic list and helper functions for mapping ICD codes or diagnosis text to disease tags. |
+| `run_pubmed.py` | One-off PubMed scraping CLI for arbitrary keyword searches. |
+| `run_patient.py` | Patient-driven PubMed scraping CLI. Resolves disease topics from a user's extracted graph diagnoses. |
+| `run_topics.py` | Batch scraping CLI for the curated disease list in `topics.py`. |
+| `types.py` | TypedDict contracts for scraped raw records. |
+| `log.py` | Simple file logger for scraper warnings/errors. |
+| `requirements.txt` | Isolated dependency set for the scraper subsystem. |
+
+## Data Flow Details
+
+### 1. Target creation
+
+Targets describe the desired scrape, not the scraping mechanics.
+
+`PubMedTarget` accepts:
+
+- `keywords`: list of PubMed search terms.
+- `max_results`: maximum search results returned by Entrez.
+- `disease`: optional stable disease tag stored in each vector chunk's metadata.
+
+Example:
+
+```python
+target = PubMedTarget(
+    keywords=["prostate cancer", "prostate adenocarcinoma"],
+    max_results=10,
+    disease="prostate_cancer",
+)
+```
+
+### 2. PubMed search
+
+`PubMedScraper.search_free_fulltext()` calls `Entrez.esearch()` with:
+
+- `db="pubmed"`
+- `sort="relevance"`
+- `retmode="xml"`
+- `retmax=max_results`
+- `term="<keywords> AND free full text[sb]"`
+
+The free-full-text filter reduces the chance of finding papers that cannot provide
+usable content, although full PDF downloads can still fail depending on the publisher.
+
+### 3. Dedup filtering
+
+Before any download or embedding work, `PubMedScraper.get_all_possible_elements()`
+passes candidate PMIDs to `ledger.filter_new()`.
+
+The ledger chooses one backend per Python process:
+
+- Firestore when `shared.firestore.get_firestore()` works.
+- Local JSON fallback when Firebase credentials/configuration are missing or
+  unavailable.
+
+```mermaid
+flowchart TD
+    PMIDs[Candidate PMIDs from PubMed] --> BackendChoice{Can Firestore initialize?}
+    BackendChoice -->|yes| Firestore[literature_papers collection]
+    BackendChoice -->|no| Local[data/pubmed/index.json]
+    Firestore --> Diff[Return PMIDs not present]
+    Local --> Diff
+    Diff --> Scrape[Only new PMIDs are scraped]
+```
+
+Firestore is the intended backend for deployed/cloud usage because local filesystem
+state is ephemeral in Cloud Run. The local JSON index is useful for development.
+
+### 4. Scraping one article
+
+For each new PMID, `scrape_and_save()` runs the template workflow from
+`BaseScraper`:
+
+1. `_scrape()` fetches metadata and article text.
+2. `_save()` writes the raw scraped dictionary to `data/pubmed/raw/<pmid>.json`.
+3. `get_documents()` converts the raw dictionary to LangChain `Document` chunks.
+4. `_save_vector_docs()` embeds and writes chunks to AstraDB.
+5. `_record_scraped()` records the PMID in the ledger.
+
+### 5. Metadata extraction
+
+`PubMedScraper._scrape()` calls `Entrez.efetch()` and derives:
+
+- `title`
+- `authors`
+- `publicationDate`
+- `ref` as DOI URL
+- `abstract`
+- `transcript` from downloaded PDF text, when available
+
+The raw saved JSON has this shape:
+
+```json
+{
+  "abstract": "Article abstract text...",
+  "authors": "Author One, Author Two",
+  "publicationDate": "2024",
+  "ref": "https://doi.org/...",
+  "title": "Article title",
+  "transcript": "Extracted PDF full text..."
+}
+```
+
+### 6. PDF download and extraction
+
+`get_paper_from_doi()` uses `paperscraper.pdf.save_pdf()` to download a PDF into
+`scrapers/data/papers/`.
+
+`get_txt_from_pdf()` uses `pypdf.PdfReader` to concatenate text from all pages.
+By default, the temporary PDF is deleted after text extraction.
+
+If text extraction fails, the scraper logs a warning and continues.
+
+### 7. Abstract fallback
+
+`get_documents()` prefers full PDF text:
+
+```python
+content = transcript or abstract
+```
+
+If full text is unavailable, the abstract is still chunked and embedded. This keeps
+the corpus useful even when publisher PDF access fails.
+
+The chunk metadata includes:
+
+```python
+{
+    "abstract": "...",
+    "authors": "...",
+    "publicationDate": "...",
+    "title": "...",
+    "ref": "https://doi.org/...",
+    "source": "pubmed",
+    "pmid": "...",
+    "disease": "prostate_cancer",
+    "full_text": True
+}
+```
+
+### 8. Chunking
+
+`splitter.py` uses:
+
+- `chunk_size=512`
+- `chunk_overlap=25`
+- `length_function=len`
+- `is_separator_regex=False`
+
+Each chunk becomes one LangChain `Document` with identical article-level metadata.
+
+### 9. Vector storage
+
+`BaseScraper._save_vector_docs()` creates an `AstraDBVectorStore` with:
+
+- `OpenAIEmbeddings(api_key=os.getenv("OPEN_AI_API"))`
+- `ASTRA_DB_API_ENDPOINT`
+- `ASTRA_DB_TOKEN`
+- `ASTRA_DB_NAMESPACE`
+- `ASTRA_DB_COLLECTION`
+
+Then it calls:
+
+```python
+vector_store.add_documents(documents=documents)
+```
+
+The Astra collection embedding dimension must match the embedding model used by
+LangChain's default `OpenAIEmbeddings` configuration.
+
+### 10. Ledger write
+
+`PubMedScraper._record_scraped()` calls:
+
+```python
+ledger.record(
+    pmid,
+    doi=...,
+    title=...,
+    disease=...,
+    chunk_count=len(documents),
+    full_text=...,
+    source="pubmed",
+)
+```
+
+With Firestore enabled, this writes to the global `literature_papers` collection.
+With the local fallback, it appends the PMID to `data/pubmed/index.json`.
+
+## Storage Illustration
+
+```mermaid
+flowchart TB
+    subgraph LocalFiles["scrapers/data/ (gitignored local artifacts)"]
+        RawJson["pubmed/raw/<pmid>.json\nraw scraped metadata + transcript"]
+        IndexJson["pubmed/index.json\nlocal fallback dedup index"]
+        TempPdf["papers/<title>.pdf\ntemporary during extraction"]
+        LogTxt["log/log.txt\nwarnings and failures"]
+    end
+
+    subgraph Firestore["Firestore"]
+        Literature["literature_papers/<pmid>\nlightweight global dedup ledger"]
+    end
+
+    subgraph Astra["AstraDB"]
+        Vectors["ASTRA_DB_COLLECTION\nchunk text + embeddings + metadata"]
+    end
+
+    RawJson --> Vectors
+    TempPdf --> RawJson
+    Literature -.preferred dedup.-> Vectors
+    IndexJson -.fallback dedup.-> Vectors
+```
+
+## Environment Configuration
+
+Add these values to `Backend/.env` or another environment loaded before execution.
+The package loads `Backend/.env` automatically from `scrapers/__init__.py`.
+
+```bash
+OPEN_AI_API=sk-...
+ASTRA_DB_API_ENDPOINT=https://<db-id>-<region>.apps.astra.datastax.com
+ASTRA_DB_TOKEN=AstraCS:...
+ASTRA_DB_NAMESPACE=default_keyspace
+ASTRA_DB_COLLECTION=health_ai
+
+# Optional, but recommended by NCBI.
+NCBI_ENTREZ_EMAIL=you@example.com
+NCBI_API_KEY=...
+
+# Required only for patient-driven scraping.
+NEO4J_URI=neo4j+s://...
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=...
+NEO4J_DATABASE=neo4j
+```
+
+Important naming note: this package currently uses `OPEN_AI_API`, not
+`OPENAI_API_KEY`. The name mirrors the original project it was ported from.
+
+## Installation
+
+Install scraper dependencies from the `Backend/` directory into your active Python
+environment:
+
+```bash
+pip install -r scrapers/requirements.txt
+```
+
+These dependencies are intentionally separate from the rest of the backend.
+
+## Running the Scrapers
+
+Run commands from `Backend/` so `scrapers` and `shared` are importable as packages.
+
+### One-off keyword scrape
+
+```bash
+python -m scrapers.run_pubmed --keywords nutrition health --max-results 3
+```
+
+This searches PubMed for `nutrition health`, filters out already-ingested PMIDs,
+then embeds up to three new papers.
+
+### Curated disease scrape
+
+```bash
+python -m scrapers.run_topics --max-results 5
+```
+
+This iterates every topic in `topics.DISEASE_TOPICS`.
+
+To scrape one disease:
+
+```bash
+python -m scrapers.run_topics --disease prostate_cancer --max-results 10
+```
+
+Known disease tags currently include:
+
+- `prostate_cancer`
+- `breast_cancer`
+- `type2_diabetes`
+- `hypertension`
+
+## Curated Disease Topics
+
+`topics.py` stores the corpus taxonomy in code so changes are reviewable in git.
+
+Each topic contains:
+
+| Field | Meaning |
+| --- | --- |
+| `disease` | Stable slug used in vector metadata and later retrieval filters. Do not rename casually. |
+| `label` | Human-readable disease name. |
+| `icd_prefixes` | ICD-10 prefixes for mapping structured diagnoses. |
+| `aliases` | Lowercase free-text diagnosis substrings, including German terms. |
+| `keywords` | PubMed query terms used during scraping. |
+
+The helper functions are:
+
+- `disease_for_icd(icd_code)`: maps ICD-10 prefixes to a disease tag.
+- `disease_for_text(text)`: maps diagnosis text to a disease tag using aliases.
+- `diseases_for_diagnosis(name, icd_code)`: prefers ICD mapping, then text mapping.
+
+## Patient-Driven Scraping
+
+The patient-driven flow uses the existing Graphiti patient graph to decide which
+PubMed topics to scrape.
+
+The backend ingestion worker stores patient facts in Neo4j through Graphiti with:
+
+```text
+group_id = uid
+```
+
+For that reason, the first supported patient-driven runner accepts a Firebase
+`uid`, not a raw hospital patient number.
+
+```mermaid
+flowchart LR
+    UID[Firebase UID\nGraphiti group_id]
+    Neo4j[Neo4j / Graphiti graph]
+    Diagnoses[Diagnosis nodes\nname + icd_code + properties]
+    Mapping[topics.py mapping\nICD prefixes + aliases]
+    Topics[Curated disease topics]
+    Keywords[Safe PubMed keywords]
+    PubMed[PubMed scrape]
+    Astra[AstraDB corpus]
+
+    UID --> Neo4j
+    Neo4j --> Diagnoses
+    Diagnoses --> Mapping
+    Mapping --> Topics
+    Topics --> Keywords
+    Keywords --> PubMed
+    PubMed --> Astra
+```
+
+Dry-run first to see what the graph resolves to:
+
+```bash
+python -m scrapers.run_patient --uid <firebase_uid> --dry-run
+```
+
+Then scrape the matching PubMed topics:
+
+```bash
+python -m scrapers.run_patient --uid <firebase_uid> --max-results 5
+```
+
+The runner does not send the patient's narrative, documents, or private details to
+PubMed. It only sends generic curated keywords such as `prostate cancer` after the
+local graph diagnosis has been mapped to a disease topic.
+
+If no disease is resolved, update `topics.py` with additional aliases or ICD
+prefixes that match the diagnosis terms found in the graph.
+
+## Dedup Ledger Details
+
+The Firestore ledger document is represented by `shared.models.literature_paper`.
+One document is stored per unique PMID.
+
+```mermaid
+classDiagram
+    class LiteraturePaper {
+        string pmid
+        string doi
+        string title
+        list~string~ diseases
+        int chunk_count
+        bool full_text
+        string source
+        datetime embedded_at
+        datetime updated_at
+    }
+```
+
+When a paper is discovered again under a different disease:
+
+- The scraper does not re-download the paper.
+- The scraper does not re-embed its chunks.
+- Firestore appends the new disease tag with `ArrayUnion`.
+
+This keeps the vector store from filling with duplicate chunks while preserving the
+fact that one paper may be relevant to multiple disease topics.
+
+## Error Handling
+
+The scraper is resilient to common PubMed/PDF issues:
+
+- Missing DOI, title, authors, date, or abstract return empty strings rather than
+  crashing the whole run.
+- PDF download or extraction failure is logged and the scraper falls back to the
+  abstract when possible.
+- If `_scrape()` returns an empty dictionary, `scrape_and_save()` logs that no data
+  was found and skips vector insertion.
+- If Firestore is unavailable, the ledger falls back to `data/pubmed/index.json`.
+
+Errors and warnings are appended to:
+
+```text
+Backend/scrapers/data/log/log.txt
+```
+
+## Local Artifacts
+
+All runtime artifacts are under `Backend/scrapers/data/` and are gitignored:
+
+```text
+scrapers/data/
+  pubmed/
+    index.json
+    raw/
+      <pmid>.json
+  papers/
+    <temporary downloaded PDFs>
+  log/
+    log.txt
+```
+
+## Extension Guide
+
+To add another literature source, follow the existing target/scraper pattern:
+
+1. Create a target class that extends `BaseTarget`.
+2. Create a scraper class that extends `BaseScraper`.
+3. Implement `index_file()`, `base_dir()`, `_scrape()`,
+   `get_all_possible_elements()`, and `get_documents()`.
+4. Reuse `get_text_chunks()` unless the source needs a different chunking policy.
+5. Reuse or extend `ledger.py` if deduplication should remain global.
+6. Add a small CLI runner like `run_pubmed.py`.
+7. Add source-specific metadata fields while preserving the common fields:
+   `source`, `ref`, and an external stable ID.
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to check |
+| --- | --- | --- |
+| `ModuleNotFoundError: scrapers` | Command was not run from `Backend/`. | Run `python -m scrapers.run_pubmed ...` inside `Backend/`. |
+| `ModuleNotFoundError: shared` | Same import-path issue, or backend root not on Python path. | Run from `Backend/`. |
+| `ModuleNotFoundError: neo4j` | Patient-driven scraping dependencies are not installed. | Run `pip install -r scrapers/requirements.txt`. |
+| `run_patient` finds no diagnoses | The user has no extracted Graphiti Diagnosis nodes, or the wrong UID was used. | Confirm the patient's documents reached `EXTRACTED` and use the Firebase UID. |
+| `run_patient` finds diagnoses but no topics | The diagnosis terms do not match the curated aliases/ICD prefixes. | Add aliases or ICD prefixes in `scrapers/topics.py`. |
+| AstraDB authentication error | Missing or invalid Astra env vars. | Check `ASTRA_DB_API_ENDPOINT`, `ASTRA_DB_TOKEN`, `ASTRA_DB_NAMESPACE`, `ASTRA_DB_COLLECTION`. |
+| OpenAI embedding error | Missing `OPEN_AI_API` or incompatible embedding configuration. | Verify the key and the Astra collection vector dimension. |
+| Firestore warning followed by local fallback | Firebase credentials are unavailable locally. | Accept the fallback for local runs, or configure Firebase admin credentials. |
+| Few or no PDFs extracted | PubMed free-full-text does not guarantee publisher PDF access. | Confirm abstracts are still being embedded through the fallback path. |
+| Duplicate papers in searches | Expected PubMed overlap across topics. | Firestore/local ledger should prevent duplicate embedding. |
+
+## Current Limitations
+
+- Only PubMed is implemented.
+- Retrieval from the scraped AstraDB corpus is not yet wired into `api/chat.py`.
+- PDF extraction quality depends on publisher formatting and `pypdf`.
+- The local JSON ledger is not suitable for concurrent or distributed production
+  scraping.
+- The embedding model is implicit through LangChain's `OpenAIEmbeddings` default.
+
+## Quick Reference
+
+```bash
+# From repository root
+cd Backend
+
+# Install isolated scraper dependencies
+pip install -r scrapers/requirements.txt
+
+# Scrape arbitrary PubMed keywords
+python -m scrapers.run_pubmed --keywords nutrition health --max-results 3
+
+# Scrape all curated disease topics
+python -m scrapers.run_topics --max-results 5
+
+# Scrape one curated disease topic
+python -m scrapers.run_topics --disease prostate_cancer --max-results 10
+
+# Resolve a patient's diagnoses to topics without scraping
+python -m scrapers.run_patient --uid <firebase_uid> --dry-run
+
+# Scrape PubMed topics relevant to one patient graph
+python -m scrapers.run_patient --uid <firebase_uid> --max-results 5
+```

--- a/Backend/scrapers/__init__.py
+++ b/Backend/scrapers/__init__.py
@@ -1,0 +1,40 @@
+"""Standalone scraping subsystem (ported from amos2024ss06-health-ai-framework, MIT).
+
+Scrapes external public sources and ingests chunked text into an AstraDB vector
+store. This is intentionally decoupled from the Neo4j / Graphiti per-user knowledge
+graph: it is a separate, global reference corpus with its own storage and retrieval.
+
+Currently only the PubMed source is ported. Run from ``Backend/``:
+
+    python -m scrapers.run_pubmed --keywords nutrition health --max-results 3
+
+All scraped artefacts (raw JSON, temp PDFs, dedup index, logs) live under
+``scrapers/data/`` (gitignored) so behaviour does not depend on the current working
+directory.
+"""
+
+import json
+import os
+
+from dotenv import load_dotenv
+
+PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+BACKEND_DIR = os.path.dirname(PACKAGE_DIR)
+
+# All scraped artefacts are anchored to the package, not the CWD.
+DATA_DIR = os.path.join(PACKAGE_DIR, 'data')
+RAW_DIR_PATH = os.path.join(DATA_DIR, 'pubmed', 'raw')
+INDEX_FILE_PATH = os.path.join(DATA_DIR, 'pubmed', 'index.json')
+PAPERS_DIR = os.path.join(DATA_DIR, 'papers')
+LOG_DIR = os.path.join(DATA_DIR, 'log')
+
+for _d in (RAW_DIR_PATH, PAPERS_DIR, LOG_DIR):
+    os.makedirs(_d, exist_ok=True)
+
+if not os.path.exists(INDEX_FILE_PATH):
+    with open(INDEX_FILE_PATH, 'w') as _f:
+        _f.write(json.dumps({'indexes': []}, indent=2))
+
+# Reuse Backend/.env (AstraDB + OpenAI keys live there). Non-interactive, unlike the
+# original src/backend/__init__.py which prompted for missing values via input().
+load_dotenv(os.path.join(BACKEND_DIR, '.env'))

--- a/Backend/scrapers/base_scraper.py
+++ b/Backend/scrapers/base_scraper.py
@@ -1,0 +1,93 @@
+import json
+import os
+from abc import ABCMeta, abstractmethod
+from typing import List
+
+from langchain_astradb import AstraDBVectorStore
+from langchain_core.documents import Document
+from langchain_openai import OpenAIEmbeddings
+
+from .log import write_to_log
+from .types import TypeBaseScrappingData
+
+
+class BaseScraper(metaclass=ABCMeta):
+    def __init__(self, element_id: str):
+        self.element_id = element_id
+
+    def __repr__(self):
+        return 'Scraper(' + str(self.element_id) + ')'
+
+    @classmethod
+    @abstractmethod
+    def index_file(cls) -> str:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def base_dir(cls) -> str:
+        pass
+
+    @abstractmethod
+    def _scrape(self) -> str:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_all_possible_elements(cls, target) -> []:
+        pass
+
+    @abstractmethod
+    def get_documents(self, data: TypeBaseScrappingData) -> List[Document]:
+        pass
+
+    def is_scrapped(self) -> bool:
+        indexes: List[str] = json.loads(open(self.index_file(), 'r').read()).get('indexes', [])
+        return self.element_id in indexes
+
+    def _save(self, scrapped_dict: dict):
+        file_path = os.path.join(self.base_dir(), f'{self.element_id}.json')
+        with open(file_path, 'w') as file:
+            json.dump(scrapped_dict, file, indent=2)
+
+    def _save_vector_docs(self, documents: List[Document]):
+        vector_store = AstraDBVectorStore(
+            embedding=OpenAIEmbeddings(api_key=os.getenv('OPEN_AI_API')),
+            api_endpoint=os.getenv('ASTRA_DB_API_ENDPOINT'),
+            token=os.getenv('ASTRA_DB_TOKEN'),
+            namespace=os.getenv('ASTRA_DB_NAMESPACE'),
+            collection_name=os.getenv('ASTRA_DB_COLLECTION'),
+        )
+        vector_store.add_documents(documents=documents)
+
+    def scrape_and_save(self):
+        scrapped_dict = self._scrape()
+        # Check if the scrapped_dict is empty
+        if not scrapped_dict:
+            print(f'No data found for {self.element_id}')
+            write_to_log(
+                self.element_id, self.__class__.__name__, f'No data found for {self.element_id}'
+            )
+            return
+        # save scrapped json file
+        self._save(scrapped_dict)
+        # create chunk documents
+        documents = self.get_documents(scrapped_dict)
+        # Save the vector documents
+        self._save_vector_docs(documents)
+        # Mark this element as ingested (dedup ledger)
+        self._record_scraped(scrapped_dict, documents)
+
+    def _record_scraped(self, scrapped_dict: dict, documents: List[Document]):
+        """Mark this element as ingested. Override to use a richer dedup ledger.
+
+        Default: append the element_id to the local JSON index file.
+        """
+        with open(type(self).index_file(), 'r+') as file:
+            index_data = json.load(file)
+            indexes = index_data.get('indexes', [])
+            indexes.append(self.element_id)
+            index_data['indexes'] = indexes
+            # Write the updated index data back to the file
+            file.seek(0)
+            json.dump(index_data, file, indent=2)

--- a/Backend/scrapers/base_target.py
+++ b/Backend/scrapers/base_target.py
@@ -1,0 +1,14 @@
+from abc import ABCMeta, abstractmethod
+
+
+class BaseTarget(metaclass=ABCMeta):
+    @abstractmethod
+    def get_all_new_target_elements(self) -> []:
+        pass
+
+    def to_dict(self):
+        return self.__dict__
+
+    def __repr__(self):
+        attributes = ', '.join(f'{key}={value!r}' for key, value in self.__dict__.items())
+        return f'<{self.__class__.__name__} {attributes}>'

--- a/Backend/scrapers/ledger.py
+++ b/Backend/scrapers/ledger.py
@@ -1,0 +1,100 @@
+"""Dedup ledger adapter for the scraper.
+
+Primary backend is the global Firestore collection `literature_papers` (via
+shared.repositories.literature_papers) — durable and shared across instances, which
+is what a Cloud Run deployment needs (the local filesystem is ephemeral there).
+
+If Firebase is not configured / reachable (e.g. local dev without an admin key), this
+falls back to the local `data/pubmed/index.json` file so the scraper still runs and
+dedups within a single machine. The backend is decided once per process and cached.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from . import INDEX_FILE_PATH
+
+_log = logging.getLogger(__name__)
+
+_repo = None       # the shared Firestore repo module, or None for the file fallback
+_decided = False   # whether we've chosen a backend yet
+
+
+def _backend():
+    """Return the Firestore repo module, or None to use the local-file fallback."""
+    global _repo, _decided
+    if _decided:
+        return _repo
+    _decided = True
+    try:
+        from shared.firestore import get_firestore
+        from shared.repositories import literature_papers as repo
+
+        get_firestore()  # raises if Firebase creds are missing/invalid
+        _repo = repo
+        _log.info("literature ledger: using Firestore collection 'literature_papers'")
+    except Exception as e:  # ImportError, FileNotFoundError, auth/network errors
+        _repo = None
+        _log.warning(
+            "literature ledger: Firestore unavailable (%s); "
+            "falling back to local index file %s",
+            e,
+            INDEX_FILE_PATH,
+        )
+    return _repo
+
+
+# ── local-file fallback helpers ───────────────────────────────────────────────
+
+def _local_seen() -> set[str]:
+    try:
+        with open(INDEX_FILE_PATH, encoding="utf-8-sig") as f:
+            return {str(x) for x in json.load(f).get("indexes", [])}
+    except Exception:
+        return set()
+
+
+def _local_add(pmid: str) -> None:
+    seen = _local_seen()
+    seen.add(str(pmid))
+    with open(INDEX_FILE_PATH, "w", encoding="utf-8") as f:
+        json.dump({"indexes": sorted(seen)}, f, indent=2)
+
+
+# ── public API used by the scraper ────────────────────────────────────────────
+
+def filter_new(pmids) -> set[str]:
+    """Return the subset of `pmids` not yet embedded (the ones worth scraping)."""
+    pmids = {str(p) for p in pmids}
+    repo = _backend()
+    if repo is not None:
+        return pmids - repo.get_indexed_pmids(pmids)
+    return pmids - _local_seen()
+
+
+def record(
+    pmid,
+    *,
+    doi: str | None = None,
+    title: str | None = None,
+    disease: str | None = None,
+    chunk_count: int = 0,
+    full_text: bool = False,
+    source: str = "pubmed",
+) -> None:
+    """Mark a paper as embedded (or append a new disease to an existing entry)."""
+    repo = _backend()
+    if repo is not None:
+        repo.record_paper(
+            str(pmid),
+            doi=doi,
+            title=title,
+            disease=disease,
+            chunk_count=chunk_count,
+            full_text=full_text,
+            source=source,
+        )
+    else:
+        _local_add(pmid)

--- a/Backend/scrapers/log.py
+++ b/Backend/scrapers/log.py
@@ -1,0 +1,26 @@
+import datetime
+import os
+
+from . import LOG_DIR
+
+
+def write_to_log(url, message, scraping_target, log_file=None):
+    """Writes a message to a log file with a timestamp.
+
+    Parameters
+    ----------
+    url (str): Identifier of the scraped element.
+    message (str): The message to write to the log file.
+    scraping_target (str): The scraper / target the message originated from.
+    log_file (str): The path to the log file. Defaults to ``data/log/log.txt``.
+
+    """
+    if log_file is None:
+        log_file = os.path.join(LOG_DIR, 'log.txt')
+    try:
+        with open(log_file, 'a') as file:
+            timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            file.write(f'{timestamp} - {url} - {scraping_target} - {message}\n')
+        print(f'Message logged to {log_file}')
+    except Exception as e:
+        print(f'An error occurred while writing to the log file: {e}')

--- a/Backend/scrapers/patient_topics.py
+++ b/Backend/scrapers/patient_topics.py
@@ -1,0 +1,137 @@
+"""Resolve a patient's graph diagnoses to curated scraper topics.
+
+The document pipeline writes medical entities to Neo4j through Graphiti with
+``group_id = uid``. This module reads Diagnosis nodes for that UID, maps their
+name/ICD properties onto the curated disease tags in ``topics.py``, and returns
+the matching PubMed topic definitions.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from neo4j import GraphDatabase
+
+from .topics import DISEASE_TOPICS, diseases_for_diagnosis, disease_for_text
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PatientDiagnosis:
+    """Diagnosis-like entity read from the patient's Graphiti/Neo4j namespace."""
+
+    name: str | None
+    icd_code: str | None
+    properties: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class PatientTopicResolution:
+    """Resolved diseases and the source diagnoses that produced them."""
+
+    uid: str
+    diagnoses: list[PatientDiagnosis]
+    disease_tags: list[str]
+    topics: list[dict]
+
+
+def resolve_topics_for_uid(uid: str, *, limit: int = 200) -> PatientTopicResolution:
+    """Read a user's graph diagnoses and map them to curated scraper topics."""
+    diagnoses = fetch_patient_diagnoses(uid, limit=limit)
+    disease_tags = sorted(
+        {
+            tag
+            for diagnosis in diagnoses
+            if (tag := _disease_for_graph_diagnosis(diagnosis)) is not None
+        }
+    )
+    topics_by_tag = {topic["disease"]: topic for topic in DISEASE_TOPICS}
+    topics = [topics_by_tag[tag] for tag in disease_tags if tag in topics_by_tag]
+
+    _log.info(
+        "patient_topics_resolved uid=%s diagnoses=%d diseases=%s",
+        uid,
+        len(diagnoses),
+        ",".join(disease_tags),
+    )
+    return PatientTopicResolution(
+        uid=uid,
+        diagnoses=diagnoses,
+        disease_tags=disease_tags,
+        topics=topics,
+    )
+
+
+def fetch_patient_diagnoses(uid: str, *, limit: int = 200) -> list[PatientDiagnosis]:
+    """Return Diagnosis nodes from the Graphiti graph namespace for ``uid``.
+
+    Graphiti stores custom entity classes as Neo4j labels, so the primary query
+    looks for nodes labelled ``Diagnosis`` under this user's ``group_id``. A
+    small fallback also checks the serialized/entity-type properties in case a
+    future Graphiti version changes the concrete labels.
+    """
+    with _neo4j_driver() as driver:
+        database = os.environ.get("NEO4J_DATABASE", "neo4j")
+        with driver.session(database=database) as session:
+            rows = session.run(
+                """
+                MATCH (d)
+                WHERE d.group_id = $uid
+                  AND (
+                    "Diagnosis" IN labels(d)
+                    OR toLower(coalesce(properties(d).entity_type, "")) = "diagnosis"
+                    OR toLower(coalesce(properties(d).type, "")) = "diagnosis"
+                  )
+                RETURN DISTINCT properties(d) AS props
+                LIMIT $limit
+                """,
+                uid=uid,
+                limit=limit,
+            )
+            return [_diagnosis_from_props(dict(row["props"])) for row in rows]
+
+
+def _neo4j_driver():
+    return GraphDatabase.driver(
+        os.environ["NEO4J_URI"],
+        auth=(os.environ["NEO4J_USER"], os.environ["NEO4J_PASSWORD"]),
+    )
+
+
+def _diagnosis_from_props(props: dict[str, Any]) -> PatientDiagnosis:
+    return PatientDiagnosis(
+        name=_first_text(props, "name", "label", "summary", "description"),
+        icd_code=_first_text(props, "icd_code", "icd", "code"),
+        properties=props,
+    )
+
+
+def _disease_for_graph_diagnosis(diagnosis: PatientDiagnosis) -> str | None:
+    # Prefer explicit fields first.
+    tag = diseases_for_diagnosis(diagnosis.name, diagnosis.icd_code)
+    if tag:
+        return tag
+
+    # Be forgiving with Graphiti property shapes: aliases can be hidden in a
+    # summary or other extracted property even when ``name`` is too generic.
+    searchable = " ".join(
+        str(value)
+        for value in diagnosis.properties.values()
+        if isinstance(value, (str, int, float))
+    )
+    return disease_for_text(searchable)
+
+
+def _first_text(props: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = props.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None

--- a/Backend/scrapers/pubmed.py
+++ b/Backend/scrapers/pubmed.py
@@ -1,0 +1,303 @@
+import logging
+import os
+from typing import List
+
+from langchain_core.documents import Document
+
+from . import INDEX_FILE_PATH, PAPERS_DIR, RAW_DIR_PATH, ledger
+from .base_scraper import BaseScraper
+from .log import write_to_log
+from .splitter import get_text_chunks
+from .types import TypePubMedScrappingData
+
+logging.getLogger('paperscraper').setLevel(logging.ERROR)  # suppress warnings
+
+from Bio import Entrez  # noqa: E402
+from paperscraper.pdf import save_pdf  # noqa: E402
+from pypdf import PdfReader  # noqa: E402
+
+# NCBI asks callers to identify themselves; an API key raises the rate limit.
+ENTREZ_EMAIL = os.getenv('NCBI_ENTREZ_EMAIL', 'email@example.com')
+ENTREZ_API_KEY = os.getenv('NCBI_API_KEY')
+
+
+def _configure_entrez():
+    Entrez.email = ENTREZ_EMAIL
+    if ENTREZ_API_KEY:
+        Entrez.api_key = ENTREZ_API_KEY
+
+
+class PubMedScraper(BaseScraper):
+    def __init__(self, element_id: str, disease: str | None = None):
+        super().__init__(element_id=element_id)
+        self.disease = disease
+
+    @classmethod
+    def index_file(cls) -> str:
+        return INDEX_FILE_PATH
+
+    @classmethod
+    def base_dir(cls) -> str:
+        return RAW_DIR_PATH
+
+    # ---------------------------------------------------------
+    # MARK: Pubmed Queries
+    # ---------------------------------------------------------
+
+    """Get Pubmed ID's for a search query (eg. 'nutrition cancer').
+
+  only retrieves free full text papers (filter)
+  can only retrieve the first 10k search results so be specific with search terms"""
+
+    @classmethod
+    def search_free_fulltext(cls, query: str, max_results=10_000):
+        _configure_entrez()
+        handle = Entrez.esearch(
+            db='pubmed',
+            sort='relevance',
+            retmax=max_results,
+            retmode='xml',
+            term=query + ' AND free full text[sb]',
+        )
+        # optionally: could further filter with mindate and maxdate args,
+        # see docs: https://www.ncbi.nlm.nih.gov/books/NBK25499/
+        results = Entrez.read(handle)
+        handle.close()
+        return results['IdList']
+
+    """Get metadata for one pubmed id, received from search query.
+
+  Metadata is stored in a dictionary"""
+
+    def fetch_details(self, id):
+        _configure_entrez()
+        handle = Entrez.efetch(db='pubmed', retmode='xml', id=id)
+        results = Entrez.read(handle)
+        handle.close()
+        return results
+
+    # MARK: Metadata
+
+    """Retrieve doi url from details dictionary received from fetch_details() method."""
+
+    def get_doi_from_details(self, details_dict):
+        try:
+            id_list = details_dict['PubmedArticle'][0]['PubmedData']['ArticleIdList']
+            doi = ''
+            for entry in id_list:
+                attr = entry.attributes.get('IdType')
+                if attr == 'doi':
+                    doi = f'https://doi.org/{entry}'
+            return doi
+            # return doi
+        except Exception as e:
+            print('Error: pubmed_scraping: get_doi_from_pubmed_id: Could not retrieve doi.')
+            print(e)
+            return ''
+
+    """Retrieve abstract from details dictionary received from fetch_details() method."""
+
+    def get_abstract_from_details(self, details_dict):
+        try:
+            # Maybe check why 'AbstractText' is a list of texts with only 1 entry
+            # (in all examples seen)
+            abstract = details_dict['PubmedArticle'][0]['MedlineCitation']['Article']
+            abstract = abstract['Abstract']['AbstractText'][0]
+            return str(abstract)
+        except Exception as e:
+            print(
+                'Error: pubmed_scraping: get_abstract_from_details:'
+                + ' Could not retrieve abstract.'
+            )
+            print(e)
+            return ''
+
+    """Retrieve title from details dictionary received from fetch_details() method."""
+
+    def get_title_from_details(self, details_dict):
+        try:
+            title = details_dict['PubmedArticle'][0]['MedlineCitation']['Article']
+            title = title['ArticleTitle']
+            if title.endswith('.'):
+                title = title[:-1]
+            return title
+        except Exception as e:
+            print('Error: pubmed_scraping: get_title_from_details: Could not retrieve title.')
+            print(e)
+            return ''
+
+    """Retrieve authors str from details dictionary received from fetch_details() method.
+
+  the authors are separated by ', ' delimeter"""
+
+    def get_authors_from_details(self, details_dict):
+        try:
+            author_dict_list = details_dict['PubmedArticle'][0]['MedlineCitation']['Article']
+            author_dict_list = author_dict_list['AuthorList']
+            author_strings = []
+            for entry in author_dict_list:
+                author = entry['ForeName'] + ' ' + entry['LastName']
+                author_strings.append(author)
+            return ', '.join(author_strings)
+        except Exception as e:
+            print(
+                'Error: pubmed_scraping: get_authors_from_details:' + ' Could not retrieve authors.'
+            )
+            print(e)
+            return ''
+
+    """Retrieve publication date from details dict received from fetch_details() method."""
+
+    def get_publication_date_from_details(self, details_dict):
+        try:
+            date_dict = details_dict['PubmedArticle'][0]['MedlineCitation']['Article']
+            date_dict = date_dict['Journal']['JournalIssue']['PubDate']
+            # sometimes date parts are incomplete to we scrape separately
+            date = ''
+            try:
+                day = date_dict['Day']
+                date += str(day) + ' '
+            except Exception:
+                pass
+            try:
+                month = date_dict['Month']
+                date += str(month) + ' '
+            except Exception:
+                pass
+            try:
+                year = date_dict['Year']
+                date += str(year)
+            except Exception:
+                pass
+            return date
+        except Exception as e:
+            print(
+                'Error: pubmed_scraping: get_publication_date_from_details:'
+                + 'Could not retrieve date.'
+            )
+            print(e)
+            return ''
+
+    # ---------------------------------------------------------
+    # MARK: Get pdf and text
+    # ---------------------------------------------------------
+
+    def get_paper_from_doi(self, doi: str, title=None, path=PAPERS_DIR):
+        # potentially add title and then pdf files can be stored under the title
+        # instead of their doi (as filename)
+        # if the title is given, it will be used. Otherwise the file will be saved
+        # under its DOI
+        if title is None:
+            title = doi
+        if not os.path.exists(path):
+            os.makedirs(path)
+
+        paper_data = {'doi': doi}
+        filename = f'{title}'.replace('/', '').replace('?', '').replace('!', '')
+        filepath = os.path.join(path, filename)
+
+        save_pdf(paper_data, filepath=filepath + '.pdf')
+        return filename
+
+    def get_txt_from_pdf(self, filename: str, path=PAPERS_DIR, create_txt_file=False, keep_pdfs=False):
+        text = ''
+        try:
+            filepath = os.path.join(path, f'{filename}.pdf')
+            reader = PdfReader(filepath)
+            for page in reader.pages:
+                text = text + page.extract_text()
+
+            if create_txt_file:
+                f = open(filename + '.txt', 'a', encoding='utf-8')
+                f.write(text)
+                f.close()
+
+            if keep_pdfs is not True:
+                if os.path.exists(filepath):
+                    os.remove(filepath)
+        except Exception:
+            error_msg = 'Warning: PubmedScraper: Could not retrieve text data from pdf for id:'
+            write_to_log(self.element_id, self.__class__.__name__, error_msg)
+            print('Warning: PubmedScraper: Could not retrieve text data from pdf for id:', end=' ')
+            print(self.element_id)
+            # print('Error message: ' + repr(e))
+
+        return text
+
+    # ---------------------------------------------------------
+    # MARK: _scrape, get_ids
+    # ---------------------------------------------------------
+
+    def get_documents(self, data: TypePubMedScrappingData) -> List[Document]:
+        # Full-text PDFs frequently can't be downloaded (publisher paywalls / missing
+        # Wiley/Elsevier API tokens). Fall back to the abstract — which PubMed always
+        # returns — so the article still contributes something to the vector store.
+        transcript = (data.get('transcript') or '').strip()
+        abstract = (data.get('abstract') or '').strip()
+        content = transcript or abstract
+        if not content:
+            return []
+        chunks = get_text_chunks(content)
+        metadata = {
+            'abstract': data.get('abstract', ''),
+            'authors': data.get('authors', ''),
+            'publicationDate': data.get('publicationDate', ''),
+            'title': data.get('title', ''),
+            'ref': data.get('ref', ''),
+            'source': 'pubmed',
+            'pmid': self.element_id,
+            'disease': self.disease,
+            'full_text': bool(transcript),
+        }
+        documents = [Document(page_content=chunk, metadata=metadata) for chunk in chunks]
+        return documents
+
+    def _scrape(self) -> TypePubMedScrappingData:
+        try:
+            metadata = self.fetch_details(self.element_id)
+
+            title = self.get_title_from_details(metadata)
+            authors = self.get_authors_from_details(metadata)
+            publication_date = self.get_publication_date_from_details(metadata)
+            doi = self.get_doi_from_details(metadata)
+            abstract = self.get_abstract_from_details(metadata)
+
+            file_name = self.get_paper_from_doi(doi, title)
+            text_data = self.get_txt_from_pdf(file_name)
+
+            data: TypePubMedScrappingData = {
+                'abstract': abstract,
+                'authors': authors,
+                'publicationDate': publication_date,
+                'ref': doi,
+                'title': title,
+                'transcript': text_data,
+            }
+        except Exception as e:
+            write_to_log(
+                self.element_id, self.__class__.__name__, f'Error occured in PubmedScraper: {e}'
+            )
+            print(f'Error occured in PubmedScraper: {e}')
+            data = {}
+        return data
+
+    def _record_scraped(self, scrapped_dict: TypePubMedScrappingData, documents: List[Document]):
+        """Record this paper in the global dedup ledger (Firestore, or local fallback)."""
+        ledger.record(
+            self.element_id,
+            doi=scrapped_dict.get('ref'),
+            title=scrapped_dict.get('title'),
+            disease=self.disease,
+            chunk_count=len(documents),
+            full_text=bool((scrapped_dict.get('transcript') or '').strip()),
+            source='pubmed',
+        )
+
+    @classmethod
+    def get_all_possible_elements(cls, target) -> List[BaseScraper]:
+        query_str = ' '.join(target.keywords)
+        candidates = set(cls.search_free_fulltext(query_str, target.max_results))
+        # Dedup against the global ledger BEFORE downloading/embedding anything.
+        new_target_elements = ledger.filter_new(candidates)
+        disease = getattr(target, 'disease', None)
+        return [PubMedScraper(element_id=id, disease=disease) for id in new_target_elements]

--- a/Backend/scrapers/pubmed_target.py
+++ b/Backend/scrapers/pubmed_target.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from .base_target import BaseTarget
+from .pubmed import PubMedScraper
+
+
+class PubMedTarget(BaseTarget):
+    def __init__(self, keywords=None, max_results=1, disease=None):
+        self.keywords = keywords if keywords is not None else []
+        self.max_results = max_results  # max search query results for the set of keywords
+        self.disease = disease  # curated disease tag stored in each chunk's metadata
+
+    def get_all_new_target_elements(self) -> List[PubMedScraper]:
+        return PubMedScraper.get_all_possible_elements(self)

--- a/Backend/scrapers/requirements.txt
+++ b/Backend/scrapers/requirements.txt
@@ -1,0 +1,13 @@
+# Scraper subsystem deps — separate from api/ and workers/ requirements.
+# Aligned with the langchain 0.3.x line already used by the rest of the repo
+# (graphiti / workers), so installing these does NOT downgrade langchain.
+biopython>=1.83
+paperscraper>=0.2.11
+pypdf>=4.2.0
+langchain>=0.3,<0.4
+langchain-core>=0.3.74,<0.4
+langchain-text-splitters>=0.3,<0.4
+langchain-astradb>=0.5,<1.0
+langchain-openai>=0.2,<0.4
+neo4j>=5.0.0
+python-dotenv>=1.0.1

--- a/Backend/scrapers/run_patient.py
+++ b/Backend/scrapers/run_patient.py
@@ -1,0 +1,81 @@
+"""Scrape PubMed topics relevant to one patient's extracted diagnoses.
+
+The patient graph is scoped by Firebase UID (Graphiti ``group_id``), so this
+runner accepts ``--uid``. It reads Diagnosis nodes from Neo4j, maps them to the
+curated disease topics in ``topics.py``, then reuses the existing PubMed scraper
+for those topic keywords.
+
+Run from ``Backend/``:
+
+    python -m scrapers.run_patient --uid <firebase_uid> --max-results 5
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from .patient_topics import resolve_topics_for_uid
+from .pubmed_target import PubMedTarget
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scrape PubMed literature for diseases found in a patient's graph."
+    )
+    parser.add_argument(
+        "--uid",
+        required=True,
+        help="Firebase UID / Graphiti group_id for the patient namespace",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=5,
+        help="max PubMed results per resolved disease",
+    )
+    parser.add_argument(
+        "--diagnosis-limit",
+        type=int,
+        default=200,
+        help="max Diagnosis nodes to inspect from the patient graph",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print resolved diseases and keywords without scraping PubMed",
+    )
+    args = parser.parse_args()
+
+    resolution = resolve_topics_for_uid(args.uid, limit=args.diagnosis_limit)
+    print(f"Found {len(resolution.diagnoses)} diagnosis node(s) for uid {args.uid!r}.")
+
+    if not resolution.topics:
+        print("No curated disease topics matched this patient's diagnoses.")
+        print("Add aliases/ICD prefixes in scrapers/topics.py if this is expected.")
+        return
+
+    print("Resolved disease topic(s):")
+    for topic in resolution.topics:
+        print(f"  - {topic['disease']}: {', '.join(topic['keywords'])}")
+
+    if args.dry_run:
+        print("Dry run complete. No PubMed scraping was performed.")
+        return
+
+    for topic in resolution.topics:
+        print(f"\n=== {topic['label']} ({topic['disease']}) ===")
+        target = PubMedTarget(
+            keywords=topic["keywords"],
+            max_results=args.max_results,
+            disease=topic["disease"],
+        )
+        elements = target.get_all_new_target_elements()
+        print(f"  {len(elements)} new article(s).")
+        for element in elements:
+            element.scrape_and_save()
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Backend/scrapers/run_pubmed.py
+++ b/Backend/scrapers/run_pubmed.py
@@ -1,0 +1,41 @@
+"""Standalone PubMed scraper runner.
+
+Ported from amos2024ss06-health-ai-framework (MIT). Searches PubMed for free
+full-text articles matching the given keywords, downloads + extracts their text,
+chunks it, and ingests the chunks into the AstraDB vector store.
+
+Replaces the original Orchestrator/Config plumbing (which eagerly imported every
+scraper type) with a direct, PubMed-only run.
+
+Run from ``Backend/``:
+
+    python -m scrapers.run_pubmed --keywords nutrition health --max-results 3
+"""
+
+import argparse
+
+from .pubmed_target import PubMedTarget
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Scrape PubMed free-full-text articles into the AstraDB vector store.'
+    )
+    parser.add_argument(
+        '--keywords', nargs='+', default=['nutrition', 'health'], help='search keywords'
+    )
+    parser.add_argument(
+        '--max-results', type=int, default=3, help='max number of PubMed results to fetch'
+    )
+    args = parser.parse_args()
+
+    target = PubMedTarget(keywords=args.keywords, max_results=args.max_results)
+    elements = target.get_all_new_target_elements()
+    print(f'Found {len(elements)} new article(s) to scrape for keywords {args.keywords!r}.')
+    for element in elements:
+        element.scrape_and_save()
+    print('Done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/Backend/scrapers/run_topics.py
+++ b/Backend/scrapers/run_topics.py
@@ -1,0 +1,53 @@
+"""Scrape the curated disease list into the global AstraDB literature corpus.
+
+Iterates `topics.DISEASE_TOPICS`; for each disease it runs a PubMed search with that
+disease's keywords and ingests the results tagged with the disease's canonical
+`disease` metadata (so the chat retriever can filter by it later).
+
+Run from ``Backend/``:
+
+    python -m scrapers.run_topics --max-results 5
+    python -m scrapers.run_topics --disease prostate_cancer --max-results 10
+"""
+
+import argparse
+
+from .pubmed_target import PubMedTarget
+from .topics import DISEASE_TOPICS
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Scrape the curated disease list into the global AstraDB corpus.'
+    )
+    parser.add_argument(
+        '--disease', default=None, help='only scrape this one disease tag (default: all)'
+    )
+    parser.add_argument(
+        '--max-results', type=int, default=5, help='max PubMed results per disease'
+    )
+    args = parser.parse_args()
+
+    topics = DISEASE_TOPICS
+    if args.disease:
+        topics = [t for t in topics if t['disease'] == args.disease]
+        if not topics:
+            known = ', '.join(t['disease'] for t in DISEASE_TOPICS)
+            parser.error(f'unknown disease {args.disease!r}. Known: {known}')
+
+    for topic in topics:
+        print(f"\n=== {topic['label']} ({topic['disease']}) ===")
+        target = PubMedTarget(
+            keywords=topic['keywords'],
+            max_results=args.max_results,
+            disease=topic['disease'],
+        )
+        elements = target.get_all_new_target_elements()
+        print(f'  {len(elements)} new article(s).')
+        for element in elements:
+            element.scrape_and_save()
+    print('\nDone.')
+
+
+if __name__ == '__main__':
+    main()

--- a/Backend/scrapers/splitter.py
+++ b/Backend/scrapers/splitter.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+
+def get_text_chunks(text: str) -> List[str]:
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=512, chunk_overlap=25, length_function=len, is_separator_regex=False
+    )
+    return text_splitter.split_text(text=text)

--- a/Backend/scrapers/topics.py
+++ b/Backend/scrapers/topics.py
@@ -1,0 +1,93 @@
+"""Curated disease list that drives literature scraping.
+
+Each entry is one disease/topic to populate the *global* AstraDB literature corpus
+with. Fields:
+
+  disease   Canonical, stable tag stored in every chunk's metadata. This is what the
+            chat retriever filters on, and what a patient's `relevant_diseases`
+            Firestore list references — keep it slug-like and DO NOT rename casually.
+  label     Human-readable name.
+  icd_prefixes  ICD-10 code prefixes used to map a patient's `Diagnosis` entities
+                (which carry `icd_code`) onto this disease (Phase 2 / chat filter).
+  keywords  PubMed search terms used at scrape time.
+
+This list is intentionally version-controlled (not Firestore) so the corpus's shape
+is reviewable in git. The per-patient relevance index *is* in Firestore (Phase 2).
+"""
+
+# `aliases` are lowercase substrings matched against a patient's free-text Diagnosis
+# `name` (Graphiti does NOT reliably populate icd_code, and reports are often German),
+# so name-based matching — not ICD codes — is the primary mapping signal.
+DISEASE_TOPICS = [
+    {
+        'disease': 'prostate_cancer',
+        'label': 'Prostate cancer',
+        'icd_prefixes': ['C61'],
+        'aliases': ['prostate cancer', 'prostate carcinoma', 'prostate adenocarcinoma',
+                    'prostatakarzinom', 'prostata-ca', 'prostatakrebs'],
+        'keywords': ['prostate cancer', 'prostate adenocarcinoma', 'PSA prostate'],
+    },
+    {
+        'disease': 'breast_cancer',
+        'label': 'Breast cancer',
+        'icd_prefixes': ['C50'],
+        'aliases': ['breast cancer', 'breast carcinoma', 'mammakarzinom', 'brustkrebs'],
+        'keywords': ['breast cancer', 'breast carcinoma'],
+    },
+    {
+        'disease': 'type2_diabetes',
+        'label': 'Type 2 diabetes mellitus',
+        'icd_prefixes': ['E11'],
+        'aliases': ['type 2 diabetes', 'diabetes mellitus type 2', 'diabetes mellitus typ 2',
+                    'typ-2-diabetes', 'zuckerkrankheit'],
+        'keywords': ['type 2 diabetes mellitus', 'type 2 diabetes management'],
+    },
+    {
+        'disease': 'hypertension',
+        'label': 'Essential hypertension',
+        'icd_prefixes': ['I10'],
+        'aliases': ['hypertension', 'high blood pressure', 'hypertonie', 'bluthochdruck'],
+        'keywords': ['essential hypertension', 'high blood pressure treatment'],
+    },
+]
+
+# Quick lookup: ICD-10 prefix -> disease tag (built once at import).
+ICD_PREFIX_TO_DISEASE: dict[str, str] = {
+    prefix.upper(): topic['disease']
+    for topic in DISEASE_TOPICS
+    for prefix in topic.get('icd_prefixes', [])
+}
+
+
+def disease_for_icd(icd_code: str | None) -> str | None:
+    """Map a patient's ICD-10 code (e.g. 'C61.9') onto a curated disease tag."""
+    if not icd_code:
+        return None
+    code = icd_code.strip().upper()
+    # Longest prefix wins (e.g. 'C61' before 'C6').
+    for prefix in sorted(ICD_PREFIX_TO_DISEASE, key=len, reverse=True):
+        if code.startswith(prefix):
+            return ICD_PREFIX_TO_DISEASE[prefix]
+    return None
+
+
+def disease_for_text(text: str | None) -> str | None:
+    """Map a free-text diagnosis name onto a curated disease tag via aliases.
+
+    This is the PRIMARY mapping path: Graphiti stores diagnoses as free-text names
+    (often German) and rarely fills in icd_code, so we match on the name. Returns the
+    first disease whose alias is a substring of the (lowercased) text.
+    """
+    if not text:
+        return None
+    t = text.lower()
+    for topic in DISEASE_TOPICS:
+        for alias in topic.get('aliases', []):
+            if alias in t:
+                return topic['disease']
+    return None
+
+
+def diseases_for_diagnosis(name: str | None, icd_code: str | None = None) -> str | None:
+    """Resolve a Diagnosis node to a curated disease: prefer ICD, fall back to name."""
+    return disease_for_icd(icd_code) or disease_for_text(name)

--- a/Backend/scrapers/types.py
+++ b/Backend/scrapers/types.py
@@ -1,0 +1,13 @@
+from typing import TypedDict
+
+
+class TypeBaseScrappingData(TypedDict):
+    ref: str
+
+
+class TypePubMedScrappingData(TypeBaseScrappingData):
+    title: str
+    authors: list
+    publicationDate: str
+    abstract: str
+    transcript: str

--- a/Backend/shared/models/literature_paper.py
+++ b/Backend/shared/models/literature_paper.py
@@ -1,0 +1,29 @@
+"""
+Domain model for a paper in the global literature corpus.
+
+One LiteraturePaper is stored in the `literature_papers` Firestore collection per
+unique paper, keyed by its PubMed ID (pmid). This collection is the *global dedup
+ledger*: before the scraper downloads + embeds a paper it checks whether the pmid
+is already here, so the same paper is never embedded twice — even when it surfaces
+under more than one disease (the new disease is just appended to `diseases`).
+
+The heavy data (chunk embeddings) lives once in the AstraDB vector store; this ledger
+holds only the lightweight paper-level record. Patient documents reference the corpus
+by disease tag, never by copying embeddings.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class LiteraturePaper(BaseModel):
+    pmid: str
+    doi: str | None = None
+    title: str | None = None
+    diseases: list[str] = Field(default_factory=list)  # curated disease tags this paper covers
+    chunk_count: int = 0                                # number of chunks embedded into AstraDB
+    full_text: bool = False                             # True if PDF text, False if abstract-only
+    source: str = "pubmed"
+    embedded_at: datetime | None = None                 # first time the paper was embedded
+    updated_at: datetime | None = None

--- a/Backend/shared/repositories/literature_papers.py
+++ b/Backend/shared/repositories/literature_papers.py
@@ -1,0 +1,112 @@
+"""
+Repository for the `literature_papers` Firestore collection — the global dedup
+ledger for the scraped literature corpus.
+
+One document per unique paper, keyed by PubMed ID. This is a *global* collection
+(not per-user): it sits alongside `users` in the same Firestore project and records
+which papers have already been embedded into the AstraDB vector store, so the scraper
+can skip re-downloading / re-embedding papers it already has.
+
+Disease associations are append-only (`ArrayUnion`): when a paper that already exists
+is found again under a different disease, we add the disease tag rather than
+re-embedding — the chunk vectors in AstraDB are untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from google.cloud import firestore as gcp_firestore
+
+from shared.firestore import get_firestore
+from shared.models.literature_paper import LiteraturePaper
+
+_log = logging.getLogger(__name__)
+_COLLECTION = "literature_papers"
+
+
+def get_paper(pmid: str) -> LiteraturePaper | None:
+    """Return the ledger entry for a paper, or None if it has not been embedded."""
+    db = get_firestore()
+    doc = db.collection(_COLLECTION).document(str(pmid)).get()
+    if not doc.exists:
+        return None
+    return LiteraturePaper(**doc.to_dict())
+
+
+def get_indexed_pmids(pmids: set[str]) -> set[str]:
+    """Return the subset of `pmids` already present in the ledger.
+
+    Uses a single batched `get_all` read rather than one round-trip per id, so the
+    scraper's "which of these candidates are new?" diff costs one call regardless of
+    how many candidates a search returned.
+    """
+    pmids = {str(p) for p in pmids}
+    if not pmids:
+        return set()
+    db = get_firestore()
+    col = db.collection(_COLLECTION)
+    snapshots = db.get_all([col.document(p) for p in pmids])
+    return {snap.id for snap in snapshots if snap.exists}
+
+
+def record_paper(
+    pmid: str,
+    *,
+    doi: str | None = None,
+    title: str | None = None,
+    disease: str | None = None,
+    chunk_count: int = 0,
+    full_text: bool = False,
+    source: str = "pubmed",
+) -> None:
+    """Record a freshly embedded paper, or append a disease to an existing one.
+
+    Transactional so two scrape runs touching the same pmid concurrently can't tear
+    the document. On first sight the full record is written (with `embedded_at`); on
+    later sights only `diseases` (ArrayUnion) and `updated_at` are touched —
+    `chunk_count` / `embedded_at` are preserved, because the vectors are not re-created.
+    """
+    pmid = str(pmid)
+    db = get_firestore()
+    ref = db.collection(_COLLECTION).document(pmid)
+    now = datetime.now(timezone.utc)
+    new_diseases = [disease] if disease else []
+
+    @gcp_firestore.transactional
+    def _txn(transaction: gcp_firestore.Transaction) -> bool:
+        snapshot = ref.get(transaction=transaction)
+        if snapshot.exists:
+            transaction.update(
+                ref,
+                {
+                    "diseases": gcp_firestore.ArrayUnion(new_diseases),
+                    "updated_at": now,
+                },
+            )
+            return False
+        transaction.set(
+            ref,
+            {
+                "pmid": pmid,
+                "doi": doi,
+                "title": title,
+                "diseases": new_diseases,
+                "chunk_count": chunk_count,
+                "full_text": full_text,
+                "source": source,
+                "embedded_at": now,
+                "updated_at": now,
+            },
+        )
+        return True
+
+    created = _txn(db.transaction())
+    _log.info(
+        "literature_paper_%s pmid=%s disease=%s chunks=%d",
+        "created" if created else "updated",
+        pmid,
+        disease,
+        chunk_count,
+    )

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,2 +1,6 @@
 Build, user, and technical documentation
 Software architecture description
+
+## Backend subsystem docs
+
+- [Backend scrapers documentation](../Backend/scrapers/README.md)


### PR DESCRIPTION
- Added a new scraping subsystem for ingesting external public sources into an AstraDB vector store, decoupled from the Neo4j graph.
- Introduced environment variables for OpenAI API and AstraDB configuration in `.env.example`.
- Implemented base classes for scrapers and targets, including `BaseScraper` and `BaseTarget`.
- Added `PubMedScraper` class for handling PubMed-specific scraping logic.
- Introduced a ledger system for deduplication using Firestore and local file fallback.
- Created utility functions for text chunking and disease mapping.
- Added command-line scripts for running the PubMed scraper and iterating over disease topics.
- Updated requirements for the scrapers subsystem to include necessary dependencies.