### PR TITLE
fix: upgrade livekit to 2.9.4

### DIFF
--- a/frontend/ailixir/package-lock.json
+++ b/frontend/ailixir/package-lock.json
@@ -17,7 +17,7 @@
         "@expo-google-fonts/raleway": "^0.4.2",
         "@langchain/core": "^1.1.48",
         "@langchain/react": "^1.0.17",
-        "@livekit/react-native": "^2.9.2",
+        "@livekit/react-native": "2.9.4",
         "@livekit/react-native-expo-plugin": "^1.0.2",
         "@livekit/react-native-webrtc": "^137.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -3865,29 +3865,33 @@
       }
     },
     "node_modules/@livekit/react-native": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@livekit/react-native/-/react-native-2.9.2.tgz",
-      "integrity": "sha512-+WeI1o8N/guE9SkNI7J9S3hndKdUXFprGUsD8ENBnY45nL6+KLf8h0EuZCbs1N14j//0nmGERobdioaWlcELDA==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native/-/react-native-2.9.4.tgz",
+      "integrity": "sha512-00+Ylb3IiJvogHyc9XFV1jZuPAEQ93bORRjMF1ipNhqWwjGxegzVbATa03MiJPUAvv7X6kAwHEHOq+ACupMY2g==",
       "license": "Apache-2.0",
+      "workspaces": [
+        "example"
+      ],
       "dependencies": {
         "@livekit/components-react": "^2.8.1",
+        "@livekit/mutex": "^1.1.1",
         "array.prototype.at": "^1.1.1",
+        "base64-js": "1.5.1",
         "event-target-shim": "6.0.2",
         "events": "^3.3.0",
         "loglevel": "^1.8.0",
         "promise.allsettled": "^1.0.5",
-        "react-native-quick-base64": "2.1.1",
         "react-native-url-polyfill": "^1.3.0",
         "typed-emitter": "^2.1.0",
         "web-streams-polyfill": "^4.1.0",
         "well-known-symbols": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@livekit/react-native-webrtc": "^137.0.1",
-        "livekit-client": "^2.15.4",
+        "@livekit/react-native-webrtc": "^137.0.2",
+        "livekit-client": "^2.15.8",
         "react": "*",
         "react-native": "*"
       }
@@ -17718,19 +17722,6 @@
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz",
       "integrity": "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==",
       "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-quick-base64": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-native-quick-base64/-/react-native-quick-base64-2.1.1.tgz",
-      "integrity": "sha512-/L+SaapDLcLcHA3Kj0/cvEhFS/oLXyD6DUXwdckTR/75bzUjqf1FrusUTvJho/lzXnCR1VtBGn+EEvrLmkDTmw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.5.1"
-      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/frontend/ailixir/package.json
+++ b/frontend/ailixir/package.json
@@ -20,7 +20,7 @@
     "@expo-google-fonts/raleway": "^0.4.2",
     "@langchain/core": "^1.1.48",
     "@langchain/react": "^1.0.17",
-    "@livekit/react-native": "^2.9.2",
+    "@livekit/react-native": "2.9.4",
     "@livekit/react-native-expo-plugin": "^1.0.2",
     "@livekit/react-native-webrtc": "^137.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",


### PR DESCRIPTION
Upgraded the LiveKit package to version 2.9.4 to fix an Expo EAS build pipeline error (see https://github.com/livekit/client-sdk-react-native/issues/306).