### PR TITLE
feat(#236): redesign chat list + faster, seamless titles

### DIFF
--- a/Backend/api/chat.py
+++ b/Backend/api/chat.py
@@ -40,7 +40,7 @@ import asyncio
 import logging
 from typing import Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, status
+from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, Field
 
 from api.auth import get_current_user
@@ -122,28 +122,35 @@ class ChatQueryResponse(BaseModel):
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _maybe_schedule_title(
-    background: BackgroundTasks,
-    payload: ChatQueryRequest,
-    uid: str,
-) -> bool:
-    """Schedule best-effort title generation for the first turn of a chat.
+# Strong references to in-flight title tasks. asyncio only holds a weak
+# reference to a bare create_task, so without this a task can be garbage
+# collected mid-flight. We add on launch and discard on completion.
+_title_tasks: set[asyncio.Task] = set()
 
-    Returns True if a task was scheduled. Empty history is the cheap
-    "this is message #1" signal; the titler's RTDB transaction is the
-    correctness backstop (idempotent + rename-safe), so a missed or extra
-    trigger can never double-title. The task runs after the response is sent,
-    adding zero latency. The original `payload.query` is used (not the
-    contextualized form) so the title reflects what the user actually typed.
+
+def _maybe_start_title(payload: ChatQueryRequest, uid: str) -> bool:
+    """Kick off best-effort title generation for the first turn of a chat.
+
+    Returns True if a task was launched. Empty history is the cheap "this is
+    message #1" signal; the titler's RTDB transaction is the correctness
+    backstop (idempotent + rename-safe), so a missed or extra trigger can never
+    double-title. The original `payload.query` is used (not the contextualized
+    form) so the title reflects what the user actually typed.
+
+    Launched with `create_task` (not a post-response BackgroundTask) so the
+    title's Gemini call runs CONCURRENTLY with retrieve+answer. It's a short,
+    thinking-disabled call, so it typically finishes before the answer does —
+    the title is already in RTDB when the client renders the answer, instead of
+    popping in several seconds later. `generate_and_store_title` never raises,
+    so the orphaned task can't surface an unhandled exception.
     """
     if not payload.chat_id or payload.history:
         return False
-    background.add_task(
-        generate_and_store_title,
-        uid=uid,
-        chat_id=payload.chat_id,
-        query=payload.query,
+    task = asyncio.create_task(
+        generate_and_store_title(uid=uid, chat_id=payload.chat_id, query=payload.query)
     )
+    _title_tasks.add(task)
+    task.add_done_callback(_title_tasks.discard)
     return True
 
 
@@ -176,7 +183,6 @@ natural-language answer. Facts are clearly marked as current or historical.
 )
 async def chat_query(
     payload: ChatQueryRequest,
-    background: BackgroundTasks,
     user: dict = Depends(get_current_user),
 ) -> ChatQueryResponse:
     uid = user["uid"]
@@ -185,6 +191,13 @@ async def chat_query(
         "chat_query_start uid=%s query_chars=%d history_turns=%d",
         uid, len(payload.query), len(payload.history),
     )
+
+    # Kick off title generation up front so it runs concurrently with the
+    # retrieve+answer pipeline below. It depends only on the raw query, so
+    # starting here (rather than after the answer) means the title is usually
+    # written to RTDB before the answer is even ready — the client sees them
+    # appear together instead of the title lagging by seconds.
+    title_generation_scheduled = _maybe_start_title(payload, uid)
 
     # Step 1 — Contextualize
     # `contextualize_query` is designed to never raise — it returns the
@@ -300,10 +313,6 @@ async def chat_query(
             code=ErrorCode.CHAT_LLM_FAILED,
             message="Failed to generate an answer. Please try again.",
         )
-
-    # Best-effort title generation for the first turn (see helper). Runs after
-    # the response is sent, so it adds no latency to the answer.
-    title_generation_scheduled = _maybe_schedule_title(background, payload, uid)
 
     _log.info(
         "chat_query_done uid=%s query_changed=%s facts=%d entities=%d answer_len=%d title_scheduled=%s",

--- a/Backend/api/chat_pipeline/titler.py
+++ b/Backend/api/chat_pipeline/titler.py
@@ -164,6 +164,10 @@ async def _generate_title(query: str) -> str:
                 # Slight creativity reads more natural than temp 0 here; the
                 # RTDB transaction makes the write idempotent regardless.
                 temperature=0.3,
+                # Disable "thinking" — a 3-6 word title needs no reasoning
+                # budget, and thinking adds seconds of latency. Off makes the
+                # title land fast enough to appear with the answer, not after.
+                thinking_config=types.ThinkingConfig(thinking_budget=0),
             ),
         ),
         timeout=_TIMEOUT_S,

--- a/frontend/ailixir/src/app/(private)/chats/[id].tsx
+++ b/frontend/ailixir/src/app/(private)/chats/[id].tsx
@@ -1,12 +1,19 @@
 import { ChatMessages } from '@/components/organisms/';
 import { ChatInput } from '@/components/molecules';
 import { CText } from '@/components/atoms';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Platform, KeyboardAvoidingView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useHeaderHeight } from '@react-navigation/elements';
-import { useLocalSearchParams } from 'expo-router';
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { getAuth } from 'firebase/auth';
 import { FirebaseRuntimeProvider, useFirebaseRuntime } from '@/runtimes/firebase-runtime';
+import { subscribeChatTitle } from '@/lib/chat-rtdb';
+
+// Fallback while the title loads or for a chat that has none yet.
+const DEFAULT_HEADER_TITLE = 'Chat';
+// Keep a long title from colliding with the back button / running off-screen.
+const HEADER_TITLE_MAX_WIDTH = 260;
 
 function ChatScreenContent() {
   const { messages, isRunning, sendMessage, retryMessage } = useFirebaseRuntime();
@@ -42,11 +49,29 @@ function ChatScreenContent() {
 
 export default function ChatScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const [title, setTitle] = useState(DEFAULT_HEADER_TITLE);
+
+  // Mirror the chat's title into the header, live — so a title that's still
+  // being auto-generated updates here the moment it lands, matching the list.
+  useEffect(() => {
+    const uid = getAuth().currentUser?.uid;
+    if (!uid || !id) return;
+    return subscribeChatTitle(uid, id, (next) => setTitle(next.trim() || DEFAULT_HEADER_TITLE));
+  }, [id]);
 
   if (!id) return null;
 
   return (
     <FirebaseRuntimeProvider chatId={id}>
+      <Stack.Screen
+        options={{
+          headerTitle: () => (
+            <CText variant="lead" bold numberOfLines={1} style={{ maxWidth: HEADER_TITLE_MAX_WIDTH }}>
+              {title}
+            </CText>
+          ),
+        }}
+      />
       <ChatScreenContent />
     </FirebaseRuntimeProvider>
   );

--- a/frontend/ailixir/src/app/(private)/chats/index.tsx
+++ b/frontend/ailixir/src/app/(private)/chats/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getAuth } from 'firebase/auth';
 
-import { CText } from '@/components/atoms';
 import { RecentChatItem } from '@/components/molecules';
 import type { RecentChat } from '@/data/home';
 import { subscribeChats } from '@/lib/chat-rtdb';
@@ -25,15 +24,13 @@ export default function ChatsScreen() {
   }, [uid]);
 
   return (
+    // The navigation header already shows "Chats"; no in-body heading so the
+    // screen matches the design's single-title layout.
     <ScrollView flex={1} bg="$background">
-      <YStack gap={14} px={16} py={16}>
-        <CText variant="h2">Chats</CText>
-
-        <YStack gap={10}>
-          {chats.map((chat) => (
-            <RecentChatItem key={chat.id} chat={chat} deletable />
-          ))}
-        </YStack>
+      <YStack gap={10} px={16} py={16}>
+        {chats.map((chat) => (
+          <RecentChatItem key={chat.id} chat={chat} deletable />
+        ))}
       </YStack>
     </ScrollView>
   );

--- a/frontend/ailixir/src/app/_layout.tsx
+++ b/frontend/ailixir/src/app/_layout.tsx
@@ -6,6 +6,7 @@ import { Stack } from 'expo-router';
 import React from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { TamaguiProvider, useTheme } from '@tamagui/core';
 import { CText } from '@/components/atoms';
 import { Circle, Spinner } from 'tamagui';
@@ -94,10 +95,15 @@ export default function RootStackNavigator() {
   });
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <TamaguiProvider config={config} defaultTheme="light">
-        <RootStackContent />
-      </TamaguiProvider>
-    </QueryClientProvider>
+    // Root host for react-native-gesture-handler. Required for any gesture
+    // component (e.g. the swipe-to-delete rows in the chat list) to receive
+    // touches; without it gestures silently no-op, especially on Android.
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <QueryClientProvider client={queryClient}>
+        <TamaguiProvider config={config} defaultTheme="light">
+          <RootStackContent />
+        </TamaguiProvider>
+      </QueryClientProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/frontend/ailixir/src/components/molecules/list-item-container.tsx
+++ b/frontend/ailixir/src/components/molecules/list-item-container.tsx
@@ -37,7 +37,13 @@ export function ListItemContent({ href, icon, title, subtitle, meta, contentAcce
           <CText variant="lead" numberOfLines={1}>
             {title}
           </CText>
-          {subtitle && <CText variant="body">{subtitle}</CText>}
+          {/* Secondary text (chat preview, document metadata): muted and
+              clipped to one line so long values never wrap the row. */}
+          {subtitle && (
+            <CText variant="body" color="$accent5" numberOfLines={1}>
+              {subtitle}
+            </CText>
+          )}
           {meta}
         </YStack>
         {contentAccessory}

--- a/frontend/ailixir/src/components/molecules/recent-chat-item.tsx
+++ b/frontend/ailixir/src/components/molecules/recent-chat-item.tsx
@@ -1,27 +1,89 @@
-import type { RecentChat } from '@/data/home';
+import { useCallback } from 'react';
+import { Alert, type Animated } from 'react-native';
+import { Swipeable } from 'react-native-gesture-handler';
+import { getAuth } from 'firebase/auth';
+import { Sparkles, Trash2 } from '@tamagui/lucide-icons-2';
+import { Circle, YStack } from 'tamagui';
 
-import { DeleteChatButton, ListItemContent } from '@/components/molecules';
-import { MessageCircle, Trash2 } from '@tamagui/lucide-icons-2';
+import { CText } from '@/components/atoms';
+import { ListItemContent } from '@/components/molecules';
+import type { RecentChat } from '@/data/home';
+import { deleteChat } from '@/lib/chat-rtdb';
 
 type RecentChatItemProps = {
   chat: RecentChat;
   deletable?: boolean;
 };
 
-export function RecentChatItem({ chat, deletable = false }: RecentChatItemProps) {
+// Avatar + delete-action colours, taken from the chat-list design mockup.
+// White circle so the sparkle stays visible on the lavender row card (a light
+// lavender circle would blend into the card background and disappear).
+const AVATAR_BG = '#FFFFFF';
+const AVATAR_ICON = '#6F65F5'; // brand purple
+const DELETE_BG = '#FF3B30'; // iOS destructive red
+const DELETE_ACTION_WIDTH = 84;
+
+function ChatAvatar() {
   return (
-    <ListItemContent
-      href={`/(private)/chats/${chat.id}`}
-      icon={<MessageCircle size={22} />}
-      title={chat.title}
-      subtitle={chat.timeAgo}
-      contentAccessory={
-        deletable ? (
-          <DeleteChatButton chatId={chat.id} circular>
-            <Trash2 size={20} color="red" />
-          </DeleteChatButton>
-        ) : null
-      }
-    />
+    <Circle size={44} bg={AVATAR_BG}>
+      <Sparkles size={22} color={AVATAR_ICON} />
+    </Circle>
+  );
+}
+
+export function RecentChatItem({ chat, deletable = false }: RecentChatItemProps) {
+  // Confirm-then-delete. `close` collapses the open swipe panel whether the
+  // user cancels or the delete fails, so the row never gets stuck half-open.
+  const confirmDelete = useCallback(
+    (close: () => void) => {
+      Alert.alert('Delete chat', 'Are you sure you want to delete this chat?', [
+        { text: 'Cancel', style: 'cancel', onPress: close },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            const uid = getAuth().currentUser?.uid;
+            if (!uid) {
+              Alert.alert('Error', 'You must be logged in to delete chats.');
+              close();
+              return;
+            }
+            try {
+              await deleteChat(uid, chat.id);
+              // No need to close() — the row unmounts when the chat disappears
+              // from the subscription.
+            } catch (error) {
+              console.error('Delete chat error:', error);
+              Alert.alert('Error', 'Failed to delete chat. Please try again.');
+              close();
+            }
+          },
+        },
+      ]);
+    },
+    [chat.id],
+  );
+
+  const row = (
+    <ListItemContent href={`/(private)/chats/${chat.id}`} icon={<ChatAvatar />} title={chat.title} subtitle={chat.preview} contentAccessory={<CText variant="caption">{chat.timeLabel}</CText>} />
+  );
+
+  // Home "Recent Chats" rows aren't deletable — render the plain row.
+  if (!deletable) return row;
+
+  // Swipe left to reveal Delete. Legacy `Swipeable` is used deliberately: it
+  // animates with React Native's core Animated API and needs no
+  // reanimated/worklets babel plugin — which this project has never configured.
+  // That keeps the gesture from forcing a build-tooling change.
+  const renderRightActions = (_progress: Animated.AnimatedInterpolation<number>, _drag: Animated.AnimatedInterpolation<number>, swipeable: Swipeable) => (
+    <YStack width={DELETE_ACTION_WIDTH} bg={DELETE_BG} items="center" justify="center" pressStyle={{ opacity: 0.85 }} onPress={() => confirmDelete(() => swipeable.close())}>
+      <Trash2 size={22} color="#fff" />
+    </YStack>
+  );
+
+  return (
+    <Swipeable renderRightActions={renderRightActions} overshootRight={false} rightThreshold={40}>
+      {row}
+    </Swipeable>
   );
 }

--- a/frontend/ailixir/src/data/home.ts
+++ b/frontend/ailixir/src/data/home.ts
@@ -19,7 +19,11 @@ export type QuickAction = {
 export type RecentChat = {
   id: string;
   title: string;
-  timeAgo: string;
+  // Preview of the last message, shown under the title in the chat row.
+  preview: string;
+  // Short relative timestamp shown on the right (e.g. "4:05 PM", "Yesterday",
+  // "May 21"). Built from the chat's last-activity time.
+  timeLabel: string;
 };
 
 export const quickActions: QuickAction[] = [
@@ -41,11 +45,4 @@ export const quickActions: QuickAction[] = [
     iconStrokeWidth: 2.2,
     iconBackground: '$blue',
   },
-];
-
-export const recentChats: RecentChat[] = [
-  { id: 'lab-reports', title: 'Lab Reports Summary', timeAgo: '2d ago' },
-  { id: 'blood-results', title: 'Blood Results Review', timeAgo: '3d ago' },
-  { id: 'invoices', title: 'Invoice Reconciliation', timeAgo: '5d ago' },
-  { id: 'timesheets-expenses', title: 'Timesheets and Expenses', timeAgo: '1w ago' },
 ];

--- a/frontend/ailixir/src/lib/chat-rtdb.ts
+++ b/frontend/ailixir/src/lib/chat-rtdb.ts
@@ -166,6 +166,24 @@ export function subscribeChats(uid: string, onNext: (chats: ChatSummary[]) => vo
   );
 }
 
+// Live subscription to a single chat's title. Used by the chat detail screen
+// to show the (possibly auto-generated) title in its header instead of a
+// static "Chat". Subscribes to the `/title` child only, so an updated title
+// (e.g. backend auto-titling landing) reflects without pulling the whole node.
+export function subscribeChatTitle(uid: string, chatId: string, onNext: (title: string) => void, onError?: (error: Error) => void): Unsubscribe {
+  const titleRef = ref(db, `${chatPath(uid, chatId)}/title`);
+  return onValue(
+    titleRef,
+    (snapshot) => {
+      const value = snapshot.val() as string | null;
+      onNext(value ?? '');
+    },
+    (error) => {
+      onError?.(error as Error);
+    },
+  );
+}
+
 export function subscribeMessages(uid: string, chatId: string, onNext: (messages: ChatMessageRecord[]) => void, onError?: (error: Error) => void): Unsubscribe {
   const messagesRef = ref(db, messagesPath(uid, chatId));
   return onValue(

--- a/frontend/ailixir/src/utils/chats.ts
+++ b/frontend/ailixir/src/utils/chats.ts
@@ -1,14 +1,39 @@
 import type { RecentChat } from '@/data/home';
 import type { ChatSummary } from '@/lib/chat-rtdb';
 
-export function chatSummaryToRecentChat(summary: ChatSummary): RecentChat {
-  const date = new Date(summary.lastMessageAt);
-  const timeAgo = date.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-  return { id: summary.chatId, title: summary.title, timeAgo };
+/**
+ * Short, relative timestamp for a chat row — mirrors the convention common
+ * chat apps use:
+ *   today      -> "4:05 PM"
+ *   yesterday  -> "Yesterday"
+ *   this year  -> "May 21"
+ *   older      -> "May 21, 2024"
+ */
+function formatTimeLabel(timestampMs: number): string {
+  const when = new Date(timestampMs);
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const startOfYesterday = startOfToday - MS_PER_DAY;
+
+  if (timestampMs >= startOfToday) {
+    return when.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  }
+  if (timestampMs >= startOfYesterday) {
+    return 'Yesterday';
+  }
+  const sameYear = when.getFullYear() === now.getFullYear();
+  return when.toLocaleDateString(undefined, sameYear ? { month: 'short', day: 'numeric' } : { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export function chatSummaryToRecentChat(summary: ChatSummary): RecentChat {
+  return {
+    id: summary.chatId,
+    title: summary.title,
+    // A freshly-created chat has no messages yet; show a neutral placeholder
+    // rather than an empty line.
+    preview: summary.lastMessagePreview?.trim() || 'No messages yet',
+    timeLabel: formatTimeLabel(summary.lastMessageAt),
+  };
 }


### PR DESCRIPTION
Frontend redesign:
- Chat rows: sparkle avatar (white circle), last-message preview under the title, relative timestamp (4:05 PM / Yesterday / May 21) on the right.
- Swipe left on a row to delete; added GestureHandlerRootView at the root.
- Chat detail header shows the chat's title (live), compact + truncated.
- Shared list row subtitle is single-line and muted; removed the duplicate 'Chats' heading and the dead recentChats mock.

Title latency:
- Generate the title concurrently with the answer pipeline instead of after it, so it's written to RTDB before the answer renders (was 4-8s late).
- Disable Gemini 'thinking' for the title call (~0.5s vs ~2-3s); a short title needs no reasoning budget.