### PR TITLE
Fix: APK upload

### DIFF
--- a/.github/workflows/build_mobile_frontend.yaml
+++ b/.github/workflows/build_mobile_frontend.yaml
@@ -66,6 +66,19 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         run: npm ci
 
-      - name: Build on EAS
+      - name: Build Android App via EAS
         working-directory: ${{ env.PROJECT_DIR }}
-        run: eas build --platform android --non-interactive --no-wait
+        run: npx eas-cli build --profile preview --platform android --non-interactive --local
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-preview-apk
+          path: |
+            *.apk
+            app-release.apk
+            android/app/build/outputs/apk/**/*.apk
+            ${{ env.PROJECT_DIR }}/*.apk
+            ${{ env.PROJECT_DIR }}/app-release.apk
+            ${{ env.PROJECT_DIR }}/android/app/build/outputs/apk/**/*.apk
+          if-no-files-found: error

--- a/frontend/ailixir/eas.json
+++ b/frontend/ailixir/eas.json
@@ -9,7 +9,10 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
     },
     "production": {
       "autoIncrement": true


### PR DESCRIPTION
- **Switched Android build artifact from `.aab` to `.apk`**: Previously, the pipeline only generated Android App Bundles (`.aab`), which were hosted exclusively on Expo and required manual conversion/EAS credentials to test. Changing the build type to `apk` allows team members and external testers to easily download and sideload the app directly from the GitHub Actions artifacts.