### PR TITLE
feat(graph): add vector RAG retrieval pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ bin/
 .DS_Store
 .env
 ai-playground/.env
+ai-playground/chat-app/.env
+ai-playground/chat-app/graph/state.py
+ai-playground/chat-app/graph/builder.py
+ai-playground/chat-app/embeddings_cache.json
+__pycache__/
+.env

--- a/ai-playground/chat-app/graph/nodes.py
+++ b/ai-playground/chat-app/graph/nodes.py
@@ -8,7 +8,9 @@ Pipeline order (called by main.py):
   1. run_guardrail    — block bad questions before any heavy LLM work
   2. classify_intent  — NEW_QUESTION or FOLLOWUP?
   3. rewrite_question — FOLLOWUP only: resolve pronouns into a full query
-  4. retrieve_context — keyword search over documents.json
+  4. retrieve_context — vector RAG search over documents.json (see
+                         graph/vector_store.py), falling back to keyword
+                         search if the embedding call fails
   5. generate_answer  — Gemini produces the final answer
 """
 
@@ -21,6 +23,8 @@ from pathlib import Path
 import vertexai
 from dotenv import load_dotenv
 from vertexai.preview.generative_models import GenerationConfig, GenerativeModel
+
+from graph import vector_store
 
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
@@ -312,13 +316,46 @@ def _load_documents() -> list[dict]:
 
 def retrieve_context(query: str, top_k: int = 3) -> tuple[str, str]:
     """
-    Keyword search over documents.json.
+    Vector RAG retrieval over documents.json (see graph/vector_store.py).
 
-    Scores each document by how many query words appear in its content,
-    returns the top-k as a single context string.
+    Embeds the (rewritten) query and runs a cosine-similarity search over
+    pre-computed chunk embeddings — real semantic search rather than
+    literal word overlap, so e.g. "how much should someone take" can match
+    a chunk about "dosage" even without a shared keyword.
+
+    If the embedding call fails for any reason (no network, no Vertex AI
+    quota, model misconfigured, etc.) this falls back to the original
+    keyword-overlap search over full documents, so a single embedding
+    outage never breaks the whole chat pipeline.
 
     Returns (context_text, source_label).
-    Replace only this function when swapping in a knowledge graph (issue #75).
+    source_label is "vector_rag" (normal path) or "keyword_fallback".
+    This is the seam to extend for the knowledge-graph hybrid (issue #187):
+    add a kg_store.search() call alongside vector_store.search() here and
+    merge the two result sets — the (context, source) contract downstream
+    doesn't need to change.
+    """
+    try:
+        hits = vector_store.search(query, top_k=top_k)
+        if not hits:
+            raise ValueError("vector index is empty")
+
+        context_text = "\n\n---\n\n".join(
+            f"[{hit['title']}]\n{hit['text']}" for hit in hits
+        )
+        scores = [round(hit["score"], 3) for hit in hits]
+        print(f"[retrieve] query: {query!r} → {len(hits)} chunk(s) via vector_rag (scores: {scores})")
+        return context_text, "vector_rag"
+
+    except Exception as exc:
+        print(f"[retrieve] vector search failed ({exc}), falling back to keyword search")
+        return _retrieve_context_keyword_fallback(query, top_k)
+
+
+def _retrieve_context_keyword_fallback(query: str, top_k: int = 3) -> tuple[str, str]:
+    """
+    Original keyword-overlap retrieval, kept as a safety-net fallback for
+    retrieve_context() when embedding-based search is unavailable.
     """
     documents  = _load_documents()
     query_words = set(query.lower().split())
@@ -335,8 +372,8 @@ def retrieve_context(query: str, top_k: int = 3) -> tuple[str, str]:
     context_text = "\n\n---\n\n".join(
         f"[{doc['title']}]\n{doc['content']}" for doc in top_docs
     )
-    print(f"[retrieve] query: {query!r} → {len(top_docs)} docs")
-    return context_text, "documents.json"
+    print(f"[retrieve] query: {query!r} → {len(top_docs)} doc(s) via keyword_fallback")
+    return context_text, "keyword_fallback"
 
 
 # ---------------------------------------------------------------------------

--- a/ai-playground/chat-app/graph/vector_store.py
+++ b/ai-playground/chat-app/graph/vector_store.py
@@ -1,0 +1,213 @@
+"""
+graph/vector_store.py
+----------------------
+Lightweight in-memory vector store that turns documents.json into a real
+Retrieval-Augmented Generation (RAG) pipeline:
+
+    documents.json -> chunk -> embed (Vertex AI) -> in-memory index -> cosine search
+
+This replaces the old keyword-overlap scoring in nodes.py with actual
+semantic retrieval, while keeping the same public contract so nothing
+upstream (nodes.py, builder.py, main.py) has to change.
+
+Design notes (see issue #187 for the longer-term hybrid KG+RAG architecture)
+-----------------------------------------------------------------------------
+- documents.json remains the "dummy" corpus for now. Pointing this at a real
+  research-paper corpus later is a data change only -- chunking, embedding,
+  and search logic stay the same.
+- Embeddings are cached on disk (embeddings_cache.json), keyed by a hash of
+  the chunk text. Restarting the app does not re-embed unchanged chunks, so
+  local dev stays fast and Vertex AI embedding calls aren't wasted.
+- This module only knows about vector search. When the knowledge graph
+  lands (#187), add a sibling module (e.g. kg_store.py) and combine both
+  result sets in nodes.py's retrieve step -- this file doesn't need to
+  change for that.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+from vertexai.language_models import TextEmbeddingModel
+
+_DATA_FILE  = Path(__file__).resolve().parent.parent / "documents.json"
+_CACHE_FILE = Path(__file__).resolve().parent.parent / "embeddings_cache.json"
+
+_EMBED_MODEL_NAME = "text-embedding-004"
+
+_CHUNK_SIZE    = 400   # characters per chunk
+_CHUNK_OVERLAP = 80    # characters of overlap between consecutive chunks
+
+_embed_model: TextEmbeddingModel | None = None
+_index: list[dict] | None = None  # each item: chunk_id, doc_id, title, text, hash, embedding
+
+
+# ---------------------------------------------------------------------------
+# Embedding model
+# ---------------------------------------------------------------------------
+
+
+def _get_embed_model() -> TextEmbeddingModel:
+    global _embed_model
+    if _embed_model is None:
+        _embed_model = TextEmbeddingModel.from_pretrained(_EMBED_MODEL_NAME)
+    return _embed_model
+
+
+def _embed_texts(texts: list[str]) -> list[list[float]]:
+    """Batches text through the Vertex AI embedding model."""
+    embeddings = _get_embed_model().get_embeddings(texts)
+    return [e.values for e in embeddings]
+
+
+# ---------------------------------------------------------------------------
+# Chunking
+# ---------------------------------------------------------------------------
+
+
+def _chunk_text(text: str, chunk_size: int = _CHUNK_SIZE, overlap: int = _CHUNK_OVERLAP) -> list[str]:
+    """
+    Sliding-window chunker that backs up to the nearest whitespace so chunks
+    never cut a word in half, with `overlap` characters shared between
+    consecutive chunks so context isn't lost at chunk boundaries.
+    """
+    text = text.strip()
+    if len(text) <= chunk_size:
+        return [text]
+
+    chunks: list[str] = []
+    start = 0
+    while start < len(text):
+        end = min(start + chunk_size, len(text))
+        if end < len(text):
+            last_space = text.rfind(" ", start, end)
+            if last_space > start:
+                end = last_space
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end >= len(text):
+            break
+        start = end - overlap
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Embedding cache (disk)
+# ---------------------------------------------------------------------------
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _load_cache() -> dict[str, list[float]]:
+    if _CACHE_FILE.exists():
+        try:
+            with open(_CACHE_FILE, encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def _save_cache(cache: dict[str, list[float]]) -> None:
+    try:
+        with open(_CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump(cache, f)
+    except OSError as exc:
+        print(f"[vector_store] failed to write embeddings cache: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Index construction
+# ---------------------------------------------------------------------------
+
+
+def build_index(force_rebuild: bool = False) -> list[dict]:
+    """
+    Loads documents.json, chunks each document, embeds every chunk (reusing
+    the disk cache for unchanged chunks), and builds the in-memory index.
+
+    Lazily triggered by the first search() call; pass force_rebuild=True to
+    re-read documents.json and pick up new/changed documents at runtime.
+    """
+    global _index
+    if _index is not None and not force_rebuild:
+        return _index
+
+    with open(_DATA_FILE, encoding="utf-8") as f:
+        documents = json.load(f)
+
+    cache = _load_cache()
+    new_cache: dict[str, list[float]] = {}
+    index: list[dict] = []
+
+    texts_to_embed: list[str] = []
+    pending: list[dict] = []
+
+    for doc in documents:
+        for i, chunk in enumerate(_chunk_text(doc["content"])):
+            chunk_hash = _hash_text(chunk)
+            item = {
+                "chunk_id": f"{doc['id']}-{i}",
+                "doc_id": doc["id"],
+                "title": doc["title"],
+                "text": chunk,
+                "hash": chunk_hash,
+            }
+            if chunk_hash in cache:
+                item["embedding"] = cache[chunk_hash]
+                new_cache[chunk_hash] = cache[chunk_hash]
+                index.append(item)
+            else:
+                texts_to_embed.append(chunk)
+                pending.append(item)
+
+    if texts_to_embed:
+        print(f"[vector_store] embedding {len(texts_to_embed)} new chunk(s) via {_EMBED_MODEL_NAME}")
+        embeddings = _embed_texts(texts_to_embed)
+        for item, embedding in zip(pending, embeddings):
+            item["embedding"] = embedding
+            new_cache[item["hash"]] = embedding
+            index.append(item)
+
+    _save_cache(new_cache)
+    _index = index
+    print(f"[vector_store] index ready: {len(index)} chunk(s) from {len(documents)} document(s)")
+    return _index
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    a_arr, b_arr = np.array(a), np.array(b)
+    denom = np.linalg.norm(a_arr) * np.linalg.norm(b_arr)
+    if denom == 0:
+        return 0.0
+    return float(np.dot(a_arr, b_arr) / denom)
+
+
+def search(query: str, top_k: int = 3) -> list[dict]:
+    """
+    Embeds the query and returns the top_k most similar chunks
+    (chunk_id, doc_id, title, text, score), best match first.
+    """
+    index = build_index()
+    if not index:
+        return []
+
+    query_embedding = _embed_texts([query])[0]
+
+    scored = [
+        {**item, "score": _cosine_similarity(query_embedding, item["embedding"])}
+        for item in index
+    ]
+    scored.sort(key=lambda x: x["score"], reverse=True)
+    return scored[:top_k]

--- a/ai-playground/chat-app/main.py
+++ b/ai-playground/chat-app/main.py
@@ -15,7 +15,9 @@ Pipeline (lives in graph/nodes.py)
   1. guardrail  — blocks injection attempts and off-topic questions
   2. intent     — classifies as NEW_QUESTION or FOLLOWUP
   3. rewrite    — if FOLLOWUP, rewrites into a self-contained query
-  4. retrieve   — keyword search over documents.json
+  4. retrieve   — vector RAG search over documents.json (embeddings via
+                   Vertex AI, cosine similarity; falls back to keyword
+                   search on embedding failure)
   5. answer     — Gemini 2.5 Flash generates the response
 
 Request format


### PR DESCRIPTION
Replaces keyword-overlap retrieval with embedding-based search (Vertex AI text-embedding-004 + cosine similarity) over documents.json chunks, falling back to keyword search if the embedding call fails. Lays groundwork for the knowledge-graph hybrid in #187.