### PR TITLE
feat(#274): include used paper references in chat reply metadata

### DIFF
--- a/Backend/api/chat.py
+++ b/Backend/api/chat.py
@@ -120,6 +120,21 @@ class ChatQueryRequest(BaseModel):
     chat_id: str | None = Field(default=None, max_length=128)
 
 
+class PaperReference(BaseModel):
+    """One research-paper source used as context for the answer.
+
+    Deduplicated per paper: several retrieved chunks from the same paper
+    collapse to a single reference. Exposed so the client can render a
+    "sources" list (title, where it's from, and a link when one is derivable).
+    """
+
+    title: str
+    source: str | None = None          # "pubmed" / "archive" / "youtube"
+    source_type: str | None = None     # "paper" / "video"
+    published_date: str | None = None
+    url: str | None = None             # link to the source, when derivable
+
+
 class ChatQueryResponse(BaseModel):
     """
     Response for POST /chat/query.
@@ -133,6 +148,10 @@ class ChatQueryResponse(BaseModel):
     `papers_used`          — number of reranked research-paper chunks used
                              (0 if the paper corpus was unavailable/empty —
                              the answer still comes from the knowledge graph).
+    `papers`               — the distinct research papers those chunks came
+                             from, most-relevant first. `papers_used` counts
+                             chunks; `len(papers)` counts unique papers. The
+                             client renders these as the answer's sources.
     `degraded_sources`     — names of the retrieval sources that could NOT be
                              read for this request ("knowledge_graph",
                              "research_papers"). Empty in the healthy case.
@@ -147,6 +166,7 @@ class ChatQueryResponse(BaseModel):
     facts_used: int
     entities_used: int
     papers_used: int = 0
+    papers: list[PaperReference] = Field(default_factory=list)
     degraded_sources: list[str] = Field(default_factory=list)
     # True when a background title-generation task was scheduled for this chat
     # (first turn + chat_id present). The title itself lands in RTDB a moment
@@ -360,6 +380,16 @@ async def chat_query(
         facts_used=retrieval.total_edges,
         entities_used=retrieval.total_nodes,
         papers_used=paper_result.total_chunks,
+        papers=[
+            PaperReference(
+                title=ref.title,
+                source=ref.source,
+                source_type=ref.source_type,
+                published_date=ref.published_date,
+                url=ref.url,
+            )
+            for ref in paper_result.references
+        ],
         degraded_sources=degraded_sources,
         title_generation_scheduled=title_generation_scheduled,
     )

--- a/Backend/api/chat_pipeline/paper_retriever.py
+++ b/Backend/api/chat_pipeline/paper_retriever.py
@@ -108,11 +108,29 @@ class PaperChunk:
     """One reranked research-paper chunk, ready for the answerer prompt."""
 
     content: str
+    title: str | None = None         # human-readable paper/video name
     source: str | None = None        # e.g. "pubmed", "archive", "youtube"
     source_type: str | None = None   # e.g. "paper", "video"
     source_id: str | None = None
     published_date: str | None = None
+    url: str | None = None           # link to the source, when derivable
     score: float | None = None       # Ranking API relevance score
+
+
+@dataclass
+class PaperReference:
+    """A distinct research-paper source used as context for an answer.
+
+    Chunks are the unit of retrieval; references are the unit a client shows.
+    Several chunks routinely come from the same paper, so `PaperRetrievalResult.
+    references` collapses them to one entry per paper — this is that entry.
+    """
+
+    title: str
+    source: str | None = None        # "pubmed" / "archive" / "youtube"
+    source_type: str | None = None   # "paper" / "video"
+    published_date: str | None = None
+    url: str | None = None
 
 
 @dataclass
@@ -134,6 +152,48 @@ class PaperRetrievalResult:
     @property
     def total_chunks(self) -> int:
         return len(self.chunks)
+
+    @property
+    def references(self) -> list[PaperReference]:
+        """The distinct papers behind `chunks`, most-relevant first.
+
+        Deduplicates by `source_id` (stable per paper) and falls back to a
+        normalised title, preserving the reranked order so the first entry is
+        the most relevant source. Chunks with nothing displayable (no title
+        and no url) are skipped — a reference the client can't render is noise.
+        """
+        seen: set[str] = set()
+        references: list[PaperReference] = []
+        for chunk in self.chunks:
+            key = (chunk.source_id or "").strip() or (chunk.title or "").strip().lower()
+            title = (chunk.title or "").strip()
+            if not key or key in seen or (not title and not chunk.url):
+                continue
+            seen.add(key)
+            references.append(
+                PaperReference(
+                    title=title,
+                    source=chunk.source,
+                    source_type=chunk.source_type,
+                    published_date=chunk.published_date,
+                    url=chunk.url,
+                )
+            )
+        return references
+
+
+def _derive_paper_url(meta: dict) -> str | None:
+    """Best-effort link to a paper: an explicit URL the scraper stored, else a
+    doi.org resolver for a bare DOI, else None. Never fabricates a URL from an
+    identifier whose format we can't be sure of."""
+    ref = str(meta.get("ref") or "").strip()
+    doi = str(meta.get("doi") or "").strip()
+    for candidate in (ref, doi):
+        if candidate.startswith(("http://", "https://")):
+            return candidate
+    if doi:
+        return f"https://doi.org/{doi}"
+    return None
 
 
 async def _vector_search(query: str) -> list:
@@ -186,10 +246,12 @@ async def _rerank(query: str, documents: list) -> list[PaperChunk]:
         chunks.append(
             PaperChunk(
                 content=doc.page_content,
+                title=meta.get("title"),
                 source=meta.get("source"),
                 source_type=meta.get("source_type"),
                 source_id=meta.get("source_id"),
                 published_date=meta.get("published_date"),
+                url=_derive_paper_url(meta),
                 score=record.score,
             )
         )


### PR DESCRIPTION
The paper-retrieval arm already fetched research-paper chunks but the response only exposed papers_used (a count), so the frontend couldn't show which papers were used.

- PaperChunk now carries the paper title + a derived source url.
- PaperRetrievalResult.references dedupes chunks into unique papers (several chunks often come from one paper), most-relevant first, dropping anything with no displayable name.
- ChatQueryResponse gains papers: list[PaperReference] (title, source, source_type, published_date, url). papers_used is unchanged (chunk count) for backward compatibility.

url is derived safely: an explicit URL if the scraper stored one, else a doi.org resolver for a bare DOI, else null — never fabricated.